### PR TITLE
Enable prometheus metrics scrape

### DIFF
--- a/k8s/service.yml
+++ b/k8s/service.yml
@@ -3,10 +3,13 @@ kind: Service
 metadata:
   name: capability-service
   namespace: $(kubernetes-namespace)
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
   labels:
     app: capability-service
     project: selfservice
-    department: devex    
+    department: devex
     component: capability-service
 spec:
   ports:


### PR DESCRIPTION
We are exposing metrics on port 8080, but we are not scraping it and removing some whitespace.