### PR TITLE
Disallow underscore in Capability name

### DIFF
--- a/src/CapabilityService.Tests/Application/TestCapabilityApplicationService.cs
+++ b/src/CapabilityService.Tests/Application/TestCapabilityApplicationService.cs
@@ -30,7 +30,6 @@ namespace DFDS.CapabilityService.Tests.Application
         [Theory]
         [InlineData("AName")]
         [InlineData("A-Name")]
-        [InlineData("A_Name")]
         [InlineData("AZ0")]
         // FIXME Temporary disabled because we need to restrict to 21 chars until downstream harald is fixed: [InlineData("A012345678901234567890123456789")]
         [InlineData("A23456789012345678901")]
@@ -68,6 +67,18 @@ namespace DFDS.CapabilityService.Tests.Application
             await sut.JoinCapability(capability.Id, stubMemberEmail);
             
             Assert.Equal(new[]{stubMemberEmail}, capability.Members.Select(x => x.Email));
+        }
+
+        [Fact]
+        public async Task throws_exception_with_underscore_in_name()
+        {
+            var sut = new CapabilityApplicationServiceBuilder()
+                .WithCapabilityRepository(new StubCapabilityRepository())
+                .Build();
+
+            var dummyName = "A_Name";
+
+            await Assert.ThrowsAsync<CapabilityValidationException>(() => sut.CreateCapability(dummyName, string.Empty));
         }
 
         [Fact]

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -12,7 +12,7 @@ namespace DFDS.CapabilityService.WebApi.Application
     public class CapabilityApplicationService : ICapabilityApplicationService
     {
         private readonly ICapabilityRepository _capabilityRepository;
-        private readonly Regex _nameValidationRegex = new Regex("^[A-Z][a-zA-Z0-9_\\-]{2,20}$", RegexOptions.Compiled);
+        private readonly Regex _nameValidationRegex = new Regex("^[A-Z][a-zA-Z0-9\\-]{2,20}$", RegexOptions.Compiled);
 
         public CapabilityApplicationService(ICapabilityRepository capabilityRepository)
         {
@@ -24,7 +24,7 @@ namespace DFDS.CapabilityService.WebApi.Application
         {
             if (!_nameValidationRegex.Match(newName).Success)
             {
-                throw new CapabilityValidationException("Name must be a string of length 3 to 32. consisting of only alphanumeric ASCII characters, starting with a capital letter. Underscores and hyphens are allowed.");
+                throw new CapabilityValidationException("Name must be a string of length 3 to 21. consisting of only alphanumeric ASCII characters, starting with a capital letter. Hyphens is allowed.");
             }
 
 
@@ -40,7 +40,7 @@ namespace DFDS.CapabilityService.WebApi.Application
         {
             if (!_nameValidationRegex.Match(name).Success)
             {
-                throw new CapabilityValidationException("Name must be a string of length 3 to 21. consisting of only alphanumeric ASCII characters, starting with a capital letter. Underscores and hyphens are allowed.");
+                throw new CapabilityValidationException("Name must be a string of length 3 to 21. consisting of only alphanumeric ASCII characters, starting with a capital letter. Hyphens is allowed.");
             }
 
             var capability = Capability.Create(name, description);


### PR DESCRIPTION
Due to AWS account_alias not allowing underscore, and the Capability name currently being too tightly coupled with that, underscore needs to be temporarily disallowed until future changes regarding this occurs