### PR TITLE
Set correlation id in scope of single event handling

### DIFF
--- a/local-development/watch-run.sh
+++ b/local-development/watch-run.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+ASPNETCORE_ENVIRONMENT="Development" \
 CAPABILITYSERVICE_DATABASE_CONNECTIONSTRING="User ID=postgres;Password=p;Host=localhost;Port=5432;Database=capabilitydb;" \
 CAPABILITY_SERVICE_KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \
 CAPABILITY_SERVICE_KAFKA_TOPIC_CAPABILITY="build.capabilities" \
 CAPABILITY_SERVICE_HUMAN_LOG="true" \
 dotnet watch --project ./../src/CapabilityService.WebApi/CapabilityService.WebApi.csproj \
-run --server.urls "http://*:50900" --no-launch-profile
+run --server.urls "http://*:50900" 
+
+# For some reason, adding this parameter suppresses Serilog output in objects with constructor DI??: --no-launch-profile

--- a/src/CapabilityService.Tests/Builders/OutboxBuilder.cs
+++ b/src/CapabilityService.Tests/Builders/OutboxBuilder.cs
@@ -36,5 +36,9 @@ namespace DFDS.CapabilityService.Tests.Builders
     public class RequestCorrelationStub : IRequestCorrelation
     {
         public string RequestCorrelationId => "CORRELATION_STUB";
+        public void OverrideCorrelationId(string _)
+        {
+            
+        }
     }
 }

--- a/src/CapabilityService.WebApi/Infrastructure/Messaging/IRequestCorrelation.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Messaging/IRequestCorrelation.cs
@@ -3,5 +3,10 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Messaging
     public interface IRequestCorrelation
     {
         string RequestCorrelationId { get; }
+        /// <summary>
+        /// Override the correlation id if it needs to be set manually. Once overridden, the stored value is sticky to the thread context
+        /// </summary>
+        /// <param name="correlationId"></param>
+        void OverrideCorrelationId(string correlationId);
     }
 }

--- a/src/CapabilityService.WebApi/Infrastructure/Messaging/RequestCorrelation.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Messaging/RequestCorrelation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using CorrelationId;
 using Serilog;
 
@@ -7,9 +8,28 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Messaging
     public class RequestCorrelation : IRequestCorrelation
     {
         private readonly ICorrelationContextAccessor _correlationContextAccessor;
+        private static readonly AsyncLocal<string> OverriddenCorrelationId = new AsyncLocal<string>();
 
         public RequestCorrelation(ICorrelationContextAccessor correlationContextAccessor) => _correlationContextAccessor = correlationContextAccessor;
 
-        public string RequestCorrelationId => _correlationContextAccessor.CorrelationContext?.CorrelationId;
+        public string RequestCorrelationId
+        {
+            get
+            {
+                return string.IsNullOrEmpty(OverriddenCorrelationId.Value)
+                    ? _correlationContextAccessor.CorrelationContext?.CorrelationId
+                    : OverriddenCorrelationId.Value;
+            }
+        }
+
+        public void OverrideCorrelationId(string correlationId)
+        {
+            Log.Information("Overriding correlationId in AsyncLocal to be {CorrelationId}", correlationId);
+            if (!String.IsNullOrEmpty(OverriddenCorrelationId.Value))
+            {
+                throw new InvalidOperationException("CorrelationId has already been overridden. CorrelationIds are locked once set in a scope.");
+            }
+            OverriddenCorrelationId.Value = string.IsNullOrWhiteSpace(correlationId) ? new Guid().ToString() : correlationId;
+        }
     }
 }

--- a/src/CapabilityService.WebApi/Program.cs
+++ b/src/CapabilityService.WebApi/Program.cs
@@ -19,7 +19,7 @@ namespace DFDS.CapabilityService.WebApi
             bool.TryParse(Environment.GetEnvironmentVariable("CAPABILITY_SERVICE_HUMAN_LOG"), out var humanLog);
 
             var logcfg = new LoggerConfiguration()
-                .MinimumLevel.Information()
+                .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .MinimumLevel.Override("Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker", LogEventLevel.Information)
                 .MinimumLevel.Override("Microsoft.AspNetCore.Hosting.Internal.WebHost", LogEventLevel.Information)
@@ -27,7 +27,7 @@ namespace DFDS.CapabilityService.WebApi
             
             if (humanLog)
             {
-                logcfg.WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}", theme: AnsiConsoleTheme.Code);
+                logcfg.WriteTo.Console(theme: AnsiConsoleTheme.Code);
             }
             else
             {

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -45,7 +45,7 @@ namespace DFDS.CapabilityService.WebApi
             services.AddHttpContextAccessor();
             services.AddCorrelationId();
             services.AddTransient<CorrelationIdRequestAppendHandler>();
-            services.AddTransient<IRequestCorrelation, RequestCorrelation>();
+            services.AddScoped<IRequestCorrelation, RequestCorrelation>();
 
 
             var connectionString = Configuration["CAPABILITYSERVICE_DATABASE_CONNECTIONSTRING"];


### PR DESCRIPTION
Would like a bit of feedback on this, particularly the AsyncLocal part.