### PR TITLE
add post/get capability-retirement endpoints to API contract

### DIFF
--- a/api-contracts/api-contract.yml
+++ b/api-contracts/api-contract.yml
@@ -148,6 +148,50 @@ paths:
           description: Ok
         404:
           description: Not Found
+  /capability-retirement/:
+    post:
+      summary: starts the process of retiring a capability
+      tags:
+        - capability-retirement
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              capabilityId:
+                type: string
+      responses:
+        201:
+          description: Created
+          headers:
+            location:
+              type: string
+              description: URI where the state of the retirement process can be retrieved
+        404:
+          description: A capability with the given id not found
+          schema:
+            $ref: '#/definitions/errorObject'
+  /capability-retirement/{capabilityRetirementId}:
+    get:
+      summary: Gets the status of a retirement process
+      tags:
+        - capability-retirement
+      parameters:
+        - in: path
+          name: capabilityRetirementId
+          type: string
+          required: true
+      responses:
+        200:
+          description: Ok
+          schema:
+            $ref: '#/definitions/retirementProcess'
+        404:
+          description: Not Found
+          schema:
+            $ref: '#/definitions/errorObject'
   /capabilities/{capabilityId}/contexts:
     post:
       summary: Adds a context to a capability 
@@ -425,3 +469,14 @@ definitions:
         type: string
       content:
         type: string
+  retirementProcess:
+    type: object
+    properties:
+      id:
+        type: string
+      status:
+        type: string
+        enum:
+        - pending
+        - processing
+        - completed

--- a/api-contracts/api-contract.yml
+++ b/api-contracts/api-contract.yml
@@ -474,6 +474,8 @@ definitions:
     properties:
       id:
         type: string
+      capabilityId:
+        type: string
       status:
         type: string
         enum:


### PR DESCRIPTION
The consumer start a retirement process by posting to the endpoint: /capability-retirement/

The consumer can get the state of the retirement process /capability-retirement/{capabilityRetirementId}
The object returned will be expanded in the future to reflect different stages of the retirement process. A stage could be:
- slack cleanup
- kubernetes teardown
- AWS account deprovisioning