### PR TITLE
add response for conflict with existing capability name on capability…

### DIFF
--- a/api-contracts/api-contract.yml
+++ b/api-contracts/api-contract.yml
@@ -59,6 +59,12 @@ paths:
           description: BadRequest
           schema:
             $ref: '#/definitions/errorObject'
+        409:
+          description: Conflict with existing capabilities
+          schema:
+            $ref: '#/definitions/errorObject'
+          examples:
+            application/json: { "message": "A capability with the name:'{name}' already exits, please give your capability a other name." }
   /capabilities/{capabilityId}:
     get:
       summary: Returns a single capability


### PR DESCRIPTION
given the response a 409 Conflict because the post is on conflict with the existing collection of capabilities where a capability has the same name as posted.