### PR TITLE
Capability factory

### DIFF
--- a/src/CapabilityService.Tests/Application/TestCapabilityApplicationService.cs
+++ b/src/CapabilityService.Tests/Application/TestCapabilityApplicationService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using DFDS.CapabilityService.Tests.Builders;
 using DFDS.CapabilityService.Tests.TestDoubles;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
+using DFDS.CapabilityService.WebApi.Domain.Factories;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using Xunit;
 namespace DFDS.CapabilityService.Tests.Application
@@ -31,6 +32,7 @@ namespace DFDS.CapabilityService.Tests.Application
         {
             var sut = new CapabilityApplicationServiceBuilder()
                 .WithCapabilityRepository(new StubCapabilityRepository())
+                .WithCapabilityFactory(new CapabilityFactory())
                 .Build();
 
             var dummyName = "A_Name";

--- a/src/CapabilityService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
+++ b/src/CapabilityService.Tests/Builders/CapabilityApplicationServiceBuilder.cs
@@ -1,5 +1,6 @@
 using DFDS.CapabilityService.Tests.TestDoubles;
 using DFDS.CapabilityService.WebApi.Application;
+using DFDS.CapabilityService.WebApi.Domain.Factories;
 using DFDS.CapabilityService.WebApi.Domain.Repositories;
 
 namespace DFDS.CapabilityService.Tests.Builders
@@ -8,11 +9,12 @@ namespace DFDS.CapabilityService.Tests.Builders
     {
         private ICapabilityRepository _capabilityRepository;
         private ITopicRepository _topicRepository;
-
+        private ICapabilityFactory _capabilityFactory;
         public CapabilityApplicationServiceBuilder()
         {
             _capabilityRepository = Dummy.Of<ICapabilityRepository>();
             _topicRepository = Dummy.Of<ITopicRepository>();
+            _capabilityFactory = Dummy.Of<ICapabilityFactory>();
         }
 
         public CapabilityApplicationServiceBuilder WithCapabilityRepository(ICapabilityRepository capabilityRepository)
@@ -26,12 +28,19 @@ namespace DFDS.CapabilityService.Tests.Builders
             _topicRepository = topicRepository;
             return this;
         }
-       
+        
+        public CapabilityApplicationServiceBuilder WithCapabilityFactory(ICapabilityFactory capabilityFactory)
+        {
+            _capabilityFactory = capabilityFactory;
+            return this;
+        }
+        
         public CapabilityApplicationService Build()
         {
             return new CapabilityApplicationService(
                 capabilityRepository: _capabilityRepository,
-                topicRepository: _topicRepository
+                topicRepository: _topicRepository,
+                capabilityFactory: _capabilityFactory
             );
         }
     }

--- a/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using DFDS.CapabilityService.Tests.Helpers;
 using DFDS.CapabilityService.WebApi.Domain.Events;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
@@ -12,9 +13,9 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
     {
         ICapabilityFactory _capabilityFactory = new CapabilityFactory();
         [Fact]
-        public void expected_domain_event_is_raised_when_creating_a_capability()
+        public async Task expected_domain_event_is_raised_when_creating_a_capability()
         {
-            var capability = _capabilityFactory.Create("Foo","bar");
+            var capability = await _capabilityFactory.Create("Foo","bar");
 
             Assert.Equal(
                 expected: new[] {new CapabilityCreated(capability.Id, "Foo")},
@@ -24,30 +25,30 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         }
         
         [Fact]
-        public void rootid_is_generated_when_creating_a_capability()
+        public async Task rootid_is_generated_when_creating_a_capability()
         {
             var name = "Foo";
-            var capability = _capabilityFactory.Create(name,"bar");
+            var capability = await _capabilityFactory.Create(name,"bar");
 
            Assert.StartsWith($"{name.ToLower()}-", capability.RootId);
    
         }
 
         [Fact]
-        public void rootid_is_generated_when_creating_a_capability_and_is_unique()
+        public async Task rootid_is_generated_when_creating_a_capability_and_is_unique()
         {
             var name = "Foo";
-            var capabilityOne = _capabilityFactory.Create(name,"bar");
-            var capabilityTwo = _capabilityFactory.Create(name, "bar");
+            var capabilityOne = await _capabilityFactory.Create(name,"bar");
+            var capabilityTwo = await _capabilityFactory.Create(name, "bar");
 
            Assert.NotEqual(capabilityOne.RootId, capabilityTwo.RootId);
         }
         
         [Fact]
-        public void rootid_is_generated_from_id()
+        public async Task rootid_is_generated_from_id()
         {
             var name = "Foo";
-            var capability = _capabilityFactory.Create(name,"bar");
+            var capability = await _capabilityFactory.Create(name,"bar");
 
             var idPartFromRootId = capability.RootId.Split('-').First();
             
@@ -68,18 +69,18 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         [InlineData("AZ0")]
         [InlineData(
             "A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A012345678901234567890123456789")]
-        public void can_create_capability_with_an_acceptable_name(string input)
+        public async Task can_create_capability_with_an_acceptable_name(string input)
         {
-            _capabilityFactory.Create(input, string.Empty);
+            await _capabilityFactory.Create(input, string.Empty);
         }
 
         [Theory]
         [InlineData("ADescription")]
         [InlineData("")]
         [InlineData(null)]
-        public void can_create_capability_with_an_acceptable_description(string input)
+        public async Task can_create_capability_with_an_acceptable_description(string input)
         {
-            _capabilityFactory.Create("Foo", input);
+            await _capabilityFactory.Create("Foo", input);
         }
     }
 }

--- a/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
@@ -2,6 +2,7 @@
 using DFDS.CapabilityService.Tests.Helpers;
 using DFDS.CapabilityService.WebApi.Domain.Events;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
+using DFDS.CapabilityService.WebApi.Domain.Factories;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using Xunit;
 
@@ -9,10 +10,11 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
 {
     public class TestCapability
     {
+        ICapabilityFactory _capabilityFactory = new CapabilityFactory();
         [Fact]
         public void expected_domain_event_is_raised_when_creating_a_capability()
         {
-            var capability = Capability.Create("Foo","bar");
+            var capability = _capabilityFactory.Create("Foo","bar");
 
             Assert.Equal(
                 expected: new[] {new CapabilityCreated(capability.Id, "Foo")},
@@ -25,7 +27,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         public void rootid_is_generated_when_creating_a_capability()
         {
             var name = "Foo";
-            var capability = Capability.Create(name,"bar");
+            var capability = _capabilityFactory.Create(name,"bar");
 
            Assert.StartsWith($"{name.ToLower()}-", capability.RootId);
    
@@ -35,8 +37,8 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         public void rootid_is_generated_when_creating_a_capability_and_is_unique()
         {
             var name = "Foo";
-            var capabilityOne = Capability.Create(name,"bar");
-            var capabilityTwo = Capability.Create(name, "bar");
+            var capabilityOne = _capabilityFactory.Create(name,"bar");
+            var capabilityTwo = _capabilityFactory.Create(name, "bar");
 
            Assert.NotEqual(capabilityOne.RootId, capabilityTwo.RootId);
         }
@@ -45,7 +47,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         public void rootid_is_generated_from_id()
         {
             var name = "Foo";
-            var capability = Capability.Create(name,"bar");
+            var capability = _capabilityFactory.Create(name,"bar");
 
             var idPartFromRootId = capability.RootId.Split('-').First();
             
@@ -58,7 +60,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         [InlineData("Aa")]
         [InlineData("A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A012345678901234567890123456789A")]
         public void cannot_create_capabilities_with_invalid_names(string input) {
-            Assert.Throws<CapabilityValidationException>(() => Capability.Create(input, string.Empty));
+            Assert.Throws<CapabilityValidationException>(() => _capabilityFactory.Create(input, string.Empty));
         }
 
         [Theory]
@@ -68,7 +70,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             "A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A0123456789012345678901234567891A012345678901234567890123456789")]
         public void can_create_capability_with_an_acceptable_name(string input)
         {
-            Capability.Create(input, string.Empty);
+            _capabilityFactory.Create(input, string.Empty);
         }
 
         [Theory]
@@ -77,7 +79,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         [InlineData(null)]
         public void can_create_capability_with_an_acceptable_description(string input)
         {
-            Capability.Create("Foo", input);
+            _capabilityFactory.Create("Foo", input);
         }
     }
 }

--- a/src/CapabilityService.Tests/Domain/Models/TestCapabilityContext.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestCapabilityContext.cs
@@ -20,14 +20,14 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             var sut = new CapabilityBuilder()
                 .WithContexts(existingContext)
                 .Build();
-            
-            
+
+
             // Act
             sut.AddContext(contextName);
 
-            
+
             // Assert
-            Assert.Empty(sut.DomainEvents);
+            Assert.Single(sut.DomainEvents);
             Assert.Equal(existingContext, sut.Contexts.Single());
         }
 
@@ -36,70 +36,72 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
         {
             // Arrange
             var contextName = "foo";
-            
+
             var sut = new CapabilityBuilder().Build();
-            
-            
+
+
             // Act
             sut.AddContext(contextName);
-            
-            
+
+
             // Assert
-            var @event = sut.DomainEvents.Single() as ContextAddedToCapability;
+            var @event =
+                sut.DomainEvents.Single(c => c.GetType() == typeof(ContextAddedToCapability)) as
+                    ContextAddedToCapability;
             Assert.Equal(
                 sut.Id,
                 @event.CapabilityId
             );
-            
+
             Assert.Equal(
                 contextName,
                 @event.ContextName
             );
-            
         }
-        
+
         [Fact]
         public void domain_event_is_not_raised_when_Context_with_same_name_is_added_multiple_times()
         {
             // Arrange
             var contextName = "foo";
-            
+
             var sut = new CapabilityBuilder().Build();
-            
-            
+
+
             // Act
             sut.AddContext(contextName);
             sut.AddContext(contextName);
             sut.AddContext(contextName);
 
-            
+
             // Assert
-            var @event = sut.DomainEvents.Single() as ContextAddedToCapability;
+            var @event =
+                sut.DomainEvents.Single(c => c.GetType() == typeof(ContextAddedToCapability)) as
+                    ContextAddedToCapability;
             Assert.Equal(
                 sut.Id,
                 @event.CapabilityId
             );
-            
+
             Assert.Equal(
                 contextName,
                 @event.ContextName
             );
-            
         }
-        
+
         [Fact]
         public void expected_context_is_added_to_contexts()
         {
             // Arrange
             var contextName = "foo";
-            
+
             var sut = new CapabilityBuilder().Build();
-            
-            
+
+
             // Act
             sut.AddContext(contextName);
-            
-            
+
+
             // Assert
             Assert.Contains(sut.Contexts, context => context.Name == contextName);
         }

--- a/src/CapabilityService.Tests/Domain/Models/TestCapabilityMember.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestCapabilityMember.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using DFDS.CapabilityService.Tests.Builders;
 using DFDS.CapabilityService.Tests.Helpers;
 using DFDS.CapabilityService.WebApi.Domain.Events;
@@ -16,8 +17,8 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             sut.StartMembershipFor(stubMemberEmail);
 
             Assert.Equal(
-                expected: new IDomainEvent[] {new MemberJoinedCapability(sut.Id, stubMemberEmail)},
-                actual: sut.DomainEvents,
+                expected: new MemberJoinedCapability(sut.Id, stubMemberEmail),
+                actual: sut.DomainEvents.Last(),
                 comparer: new PropertiesComparer<IDomainEvent>()
             );
         }
@@ -34,8 +35,8 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             sut.StopMembershipFor(stubMemberEmail);
 
             Assert.Equal(
-                expected: new IDomainEvent[] {new MemberLeftCapability(sut.Id, stubMemberEmail)},
-                actual: sut.DomainEvents,
+                expected: new MemberLeftCapability(sut.Id, stubMemberEmail),
+                actual: sut.DomainEvents.Last(),
                 comparer: new PropertiesComparer<IDomainEvent>()
             );
         }

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -50,7 +50,7 @@ namespace DFDS.CapabilityService.WebApi.Application
 
         public async Task<Capability> CreateCapability(string name, string description)
         {
-            var capability = _capabilityFactory.Create(name, description);
+            var capability = await _capabilityFactory.Create(name, description);
             await _capabilityRepository.Add(capability);
 
             return capability;

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
+using DFDS.CapabilityService.WebApi.Domain.Factories;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Domain.Repositories;
 
@@ -12,12 +13,16 @@ namespace DFDS.CapabilityService.WebApi.Application
     {
         private readonly ICapabilityRepository _capabilityRepository;
         private readonly ITopicRepository _topicRepository;
-
-        public CapabilityApplicationService(ICapabilityRepository capabilityRepository,
-            ITopicRepository topicRepository)
+        private readonly ICapabilityFactory _capabilityFactory;
+        public CapabilityApplicationService(
+            ICapabilityRepository capabilityRepository,
+            ITopicRepository topicRepository, 
+            ICapabilityFactory capabilityFactory
+        )
         {
             _capabilityRepository = capabilityRepository;
             _topicRepository = topicRepository;
+            _capabilityFactory = capabilityFactory;
         }
 
         public Task<Capability> GetCapability(Guid id) => _capabilityRepository.Get(id);
@@ -32,7 +37,7 @@ namespace DFDS.CapabilityService.WebApi.Application
 
         public async Task<Capability> UpdateCapability(Guid id, string newName, string newDescription)
         {
-            Capability.Create(newName, newDescription);
+            _capabilityFactory.Create(newName, newDescription);
 
 
             var capability = await _capabilityRepository.Get(id);
@@ -45,7 +50,7 @@ namespace DFDS.CapabilityService.WebApi.Application
 
         public async Task<Capability> CreateCapability(string name, string description)
         {
-            var capability = Capability.Create(name, description);
+            var capability = _capabilityFactory.Create(name, description);
             await _capabilityRepository.Add(capability);
 
             return capability;

--- a/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityWithSameNameExistException.cs
+++ b/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityWithSameNameExistException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace DFDS.CapabilityService.WebApi.Domain.Exceptions
+{
+    public class CapabilityWithSameNameExistException : Exception
+    {
+        
+    }
+}

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
@@ -32,7 +32,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
             return new ValueTask<Capability>(capability);
         }
 
-        private static readonly string ROOTID_SALT = "fvvjaaqpagbb";
+        private const string ROOTID_SALT = "fvvjaaqpagbb";
 
         private static string GenerateRootId(string name, Guid id)
         {

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DFDS.CapabilityService.WebApi.Domain.Exceptions;
+using DFDS.CapabilityService.WebApi.Domain.Models;
+
+namespace DFDS.CapabilityService.WebApi.Domain.Factories
+{
+    public class CapabilityFactory : ICapabilityFactory
+    {
+        private static readonly Regex ValidNameRegex = new Regex("^[A-Z][a-zA-Z0-9\\-]{2,254}$", RegexOptions.Compiled);
+
+        public Capability Create(string name, string description)
+        {
+            if (!ValidNameRegex.Match(name).Success)
+            {
+                throw new CapabilityValidationException(
+                    "Name must be a string of length 3 to 255. consisting of only alphanumeric ASCII characters, starting with a capital letter. Underscores and hyphens are allowed.");
+            }
+
+            var id = Guid.NewGuid();
+            var capability = new Capability(
+                id: id,
+                name: name,
+                rootId: GenerateRootId(name, id),
+                description: description,
+                memberships: Enumerable.Empty<Membership>(),
+                contexts: Enumerable.Empty<Context>()
+            );
+
+            return capability;
+        }
+
+        private static readonly string ROOTID_SALT = "fvvjaaqpagbb";
+
+        private static string GenerateRootId(string name, Guid id)
+        {
+            const int maxPreservedNameLength = 22;
+            
+            if (name.Length < 2)
+                throw new ArgumentException("Value is too short", nameof(name));
+
+            var microHash = new HashidsNet.Hashids(ROOTID_SALT, 5, "abcdefghijklmnopqrstuvwxyz").EncodeHex(id.ToString("N")).Substring(0,5);
+            
+            var rootId = (name.Length > maxPreservedNameLength)
+                ? $"{name.Substring(0, maxPreservedNameLength)}-{microHash}"
+                : $"{name}-{microHash}";
+            return rootId.ToLowerInvariant();
+        }
+
+    }
+}

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 
@@ -10,7 +11,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
     {
         private static readonly Regex ValidNameRegex = new Regex("^[A-Z][a-zA-Z0-9\\-]{2,254}$", RegexOptions.Compiled);
 
-        public Capability Create(string name, string description)
+        public ValueTask<Capability> Create(string name, string description)
         {
             if (!ValidNameRegex.Match(name).Success)
             {
@@ -28,7 +29,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
                 contexts: Enumerable.Empty<Context>()
             );
 
-            return capability;
+            return new ValueTask<Capability>(capability);
         }
 
         private static readonly string ROOTID_SALT = "fvvjaaqpagbb";
@@ -36,17 +37,17 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
         private static string GenerateRootId(string name, Guid id)
         {
             const int maxPreservedNameLength = 22;
-            
+
             if (name.Length < 2)
                 throw new ArgumentException("Value is too short", nameof(name));
 
-            var microHash = new HashidsNet.Hashids(ROOTID_SALT, 5, "abcdefghijklmnopqrstuvwxyz").EncodeHex(id.ToString("N")).Substring(0,5);
-            
+            var microHash = new HashidsNet.Hashids(ROOTID_SALT, 5, "abcdefghijklmnopqrstuvwxyz")
+                .EncodeHex(id.ToString("N")).Substring(0, 5);
+
             var rootId = (name.Length > maxPreservedNameLength)
                 ? $"{name.Substring(0, maxPreservedNameLength)}-{microHash}"
                 : $"{name}-{microHash}";
             return rootId.ToLowerInvariant();
         }
-
     }
 }

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DFDS.CapabilityService.WebApi.Domain.Exceptions;
+using DFDS.CapabilityService.WebApi.Domain.Models;
+using DFDS.CapabilityService.WebApi.Domain.Repositories;
+
+namespace DFDS.CapabilityService.WebApi.Domain.Factories
+{
+    public class CapabilityWithNoDuplicateNameFactory :ICapabilityFactory
+    {
+        readonly ICapabilityFactory _successor;
+        private readonly ICapabilityRepository _capabilityRepository;
+
+        public CapabilityWithNoDuplicateNameFactory(
+            ICapabilityFactory successor, 
+            ICapabilityRepository capabilityRepository
+        )
+        {
+            _successor = successor;
+            _capabilityRepository = capabilityRepository;
+        }
+
+        public async ValueTask<Capability> Create(string name, string description)
+        {
+            var existingCapabilities = await _capabilityRepository.GetAll();
+
+            var capabilitiesWithSameName = existingCapabilities.Where(c => c.Name == name);
+            
+            if(capabilitiesWithSameName.Any()) { throw  new CapabilityWithSameNameExistException();}
+
+            return await _successor.Create(name, description);
+        }
+    }
+}

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
@@ -8,15 +8,15 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
 {
     public class CapabilityWithNoDuplicateNameFactory :ICapabilityFactory
     {
-        readonly ICapabilityFactory _successor;
+        readonly ICapabilityFactory _inner;
         private readonly ICapabilityRepository _capabilityRepository;
 
         public CapabilityWithNoDuplicateNameFactory(
-            ICapabilityFactory successor, 
+            ICapabilityFactory inner, 
             ICapabilityRepository capabilityRepository
         )
         {
-            _successor = successor;
+            _inner = inner;
             _capabilityRepository = capabilityRepository;
         }
 
@@ -28,7 +28,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
             
             if(capabilitiesWithSameName.Any()) { throw  new CapabilityWithSameNameExistException();}
 
-            return await _successor.Create(name, description);
+            return await _inner.Create(name, description);
         }
     }
 }

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
@@ -8,7 +8,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
 {
     public class CapabilityWithNoDuplicateNameFactory :ICapabilityFactory
     {
-        readonly ICapabilityFactory _inner;
+        private readonly ICapabilityFactory _inner;
         private readonly ICapabilityRepository _capabilityRepository;
 
         public CapabilityWithNoDuplicateNameFactory(

--- a/src/CapabilityService.WebApi/Domain/Factories/ICapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/ICapabilityFactory.cs
@@ -1,9 +1,10 @@
+using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 
 namespace DFDS.CapabilityService.WebApi.Domain.Factories
 {
     public interface ICapabilityFactory
     {
-        Capability Create(string name, string description);
+        ValueTask<Capability> Create(string name, string description);
     }
 }

--- a/src/CapabilityService.WebApi/Domain/Factories/ICapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/ICapabilityFactory.cs
@@ -1,0 +1,9 @@
+using DFDS.CapabilityService.WebApi.Domain.Models;
+
+namespace DFDS.CapabilityService.WebApi.Domain.Factories
+{
+    public interface ICapabilityFactory
+    {
+        Capability Create(string name, string description);
+    }
+}

--- a/src/CapabilityService.WebApi/Domain/Models/Capability.cs
+++ b/src/CapabilityService.WebApi/Domain/Models/Capability.cs
@@ -30,37 +30,16 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
             Description = description;
             _memberships.AddRange(memberships);
             _contexts.AddRange(contexts);
+            
+            RaiseEvent(new CapabilityCreated(
+                capabilityId: Id,
+                capabilityName: Name
+            ));
         }
 
+        // Used by Entity Framework to construct a object
         private Capability()
         {           
-        }
-
-        private static readonly Regex ValidNameRegex = new Regex("^[A-Z][a-zA-Z0-9\\-]{2,254}$", RegexOptions.Compiled);
-
-        public static Capability Create(string name, string description)
-        {
-            if (!ValidNameRegex.Match(name).Success)
-            {
-                throw new CapabilityValidationException("Name must be a string of length 3 to 255. consisting of only alphanumeric ASCII characters, starting with a capital letter. Underscores and hyphens are allowed.");
-            }
-            
-            var id = Guid.NewGuid();
-            var capability = new Capability(
-                id: id,
-                name: name,
-                rootId: GenerateRootId(name, id),
-                description: description,
-                memberships: Enumerable.Empty<Membership>(),
-                contexts:Enumerable.Empty<Context>()
-            );
-
-            capability.RaiseEvent(new CapabilityCreated(
-                capabilityId: capability.Id,
-                capabilityName: capability.Name
-            ));
-
-            return capability;
         }
 
         public void Delete()

--- a/src/CapabilityService.WebApi/Domain/Models/Capability.cs
+++ b/src/CapabilityService.WebApi/Domain/Models/Capability.cs
@@ -9,7 +9,6 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
 {
     public class Capability : AggregateRoot<Guid>
     {
-        private static readonly string ROOTID_SALT = "fvvjaaqpagbb";
         private readonly List<Membership> _memberships = new List<Membership>();
         private readonly List<Context> _contexts = new List<Context>();
   
@@ -22,7 +21,14 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
         public IEnumerable<Context> Contexts => _contexts;
         
         
-        public Capability(Guid id, string name, string rootId, string description, IEnumerable<Membership> memberships, IEnumerable<Context> contexts)
+        public Capability(
+            Guid id, 
+            string name, 
+            string rootId, 
+            string description, 
+            IEnumerable<Membership> memberships, 
+            IEnumerable<Context> contexts
+        )
         {
             Id = id;
             Name = name;
@@ -62,21 +68,6 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
             ));
         }
 
-        private static string GenerateRootId(string name, Guid id)
-        {
-            const int maxPreservedNameLength = 22;
-            
-            if (name.Length < 2)
-                throw new ArgumentException("Value is too short", nameof(name));
-
-            var microHash = new HashidsNet.Hashids(ROOTID_SALT, 5, "abcdefghijklmnopqrstuvwxyz").EncodeHex(id.ToString("N")).Substring(0,5);
-            
-            var rootId = (name.Length > maxPreservedNameLength)
-                ? $"{name.Substring(0, maxPreservedNameLength)}-{microHash}"
-                : $"{name}-{microHash}";
-            return rootId.ToLowerInvariant();
-        }
-        
         private bool IsAlreadyMember(string memberEmail)
         {
             return Members.Any(member => member.Email.Equals(memberEmail, StringComparison.InvariantCultureIgnoreCase));

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -57,7 +57,8 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
         [HttpPost("")]
         public async Task<IActionResult> CreateCapability(CapabilityInput input)
         {
-            try {
+            try
+            {
                 var capability = await _capabilityApplicationService.CreateCapability(input.Name, input.Description);
                 var dto = Capability.Create(capability);
 
@@ -66,10 +67,19 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
                     routeValues: new {id = capability.Id},
                     value: dto
                 );
-            } catch (CapabilityValidationException tve) {
+            }
+            catch (CapabilityValidationException tve)
+            {
                 return BadRequest(new
                 {
                     Message = tve.Message
+                });
+            }
+            catch (CapabilityWithSameNameExistException)
+            {
+                return Conflict(new
+                {
+                    Message = $"A capability with the name:'{input.Name}' already exits, please give your capability a other name."
                 });
             }
         }

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -57,16 +57,10 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
         [HttpPost("")]
         public async Task<IActionResult> CreateCapability(CapabilityInput input)
         {
+            Domain.Models.Capability capability;
             try
             {
-                var capability = await _capabilityApplicationService.CreateCapability(input.Name, input.Description);
-                var dto = Capability.Create(capability);
-
-                return CreatedAtAction(
-                    actionName: nameof(GetCapability),
-                    routeValues: new {id = capability.Id},
-                    value: dto
-                );
+                capability = await _capabilityApplicationService.CreateCapability(input.Name, input.Description);
             }
             catch (CapabilityValidationException tve)
             {
@@ -82,6 +76,14 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
                     Message = $"A capability with the name:'{input.Name}' already exits, please give your capability a other name."
                 });
             }
+            
+            var dto = Capability.Create(capability);
+
+            return CreatedAtAction(
+                actionName: nameof(GetCapability),
+                routeValues: new {id = capability.Id},
+                value: dto
+            );
         }
 
         [HttpPut("{id}")]

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -61,7 +61,13 @@ namespace DFDS.CapabilityService.WebApi
                 .AddCheck("self", () => HealthCheckResult.Healthy())
                 .AddNpgSql(connectionString, tags: new[] {"backing services", "postgres"});
 
-            services.AddTransient<ICapabilityFactory, CapabilityFactory>();
+            services.AddTransient<ICapabilityFactory>(ServiceProvider => new CapabilityWithNoDuplicateNameFactory(
+                    inner: new CapabilityFactory(), 
+                    capabilityRepository: ServiceProvider.GetRequiredService<ICapabilityRepository>()
+                )
+            );
+            
+            
         }
 
         private void ConfigureApplicationServices(IServiceCollection services, string connectionString)

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -19,6 +19,7 @@ using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 using DFDS.CapabilityService.WebApi.Application;
 using DFDS.CapabilityService.WebApi.Application.EventHandlers;
 using DFDS.CapabilityService.WebApi.Domain.Events;
+using DFDS.CapabilityService.WebApi.Domain.Factories;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Domain.Repositories;
 using DFDS.CapabilityService.WebApi.Infrastructure.Events;
@@ -59,6 +60,8 @@ namespace DFDS.CapabilityService.WebApi
                 .AddHealthChecks()
                 .AddCheck("self", () => HealthCheckResult.Healthy())
                 .AddNpgSql(connectionString, tags: new[] {"backing services", "postgres"});
+
+            services.AddTransient<ICapabilityFactory, CapabilityFactory>();
         }
 
         private void ConfigureApplicationServices(IServiceCollection services, string connectionString)


### PR DESCRIPTION
Work done:

- Move the creation of a capability from a static method to a interface driven factory. 
- Create a factory to enforce the rule of only one active capability of a given name.

I used the decorator pattern to distinguish between the original concern of creation and the new concern of not allowing 2 capabilities with the same name. 