### PR TITLE
Add deleted flag to capability

### DIFF
--- a/db/migrations/20191030144735_add_deleted_to_capability.sql
+++ b/db/migrations/20191030144735_add_deleted_to_capability.sql
@@ -1,0 +1,4 @@
+-- 2019-10-30 14:47:35 : add deleted to capability
+
+ALTER TABLE public."Capability"
+ADD COLUMN "Deleted" timestamp;

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.sln
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CapabilityService.IntegrationTests", "CapabilityService.IntegrationTests\CapabilityService.IntegrationTests.csproj", "{0FB0B531-13C1-42A0-9BB5-11C06B61D6CA}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0FB0B531-13C1-42A0-9BB5-11C06B61D6CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FB0B531-13C1-42A0-9BB5-11C06B61D6CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FB0B531-13C1-42A0-9BB5-11C06B61D6CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FB0B531-13C1-42A0-9BB5-11C06B61D6CA}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.csproj
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.csproj
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Confluent.Kafka" Version="1.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
@@ -1,37 +1,42 @@
 using System;
 using System.Threading.Tasks;
 using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api;
+using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api.Model;
 using Xunit;
 
 namespace CapabilityService.IntegrationTests.Features.Capabilities
 {
     public class CapabilityDeletedScenario
     {
+        private CapabilityDto _capabilityDto;
+
         [Fact]
         public async Task CapabilityDeletedRecipe()
         {
             await Given_a_capability();
-            When_a_capability_is_deleted();
+            await When_a_capability_is_deleted();
             Then_it_wont_be_in_the_capability_list();
             And_a_event_will_be_published();
         }
 
         private async Task Given_a_capability()
         {
-            var name = "Integration-test-" + Guid.NewGuid().ToString();
+            var name = "Integration-test-" + Guid.NewGuid().ToString().Substring(0,8);
             var description = name;
 
-            await CapabilityApiClient.Capabilities.PostAsync(name, description);
+            _capabilityDto = await CapabilityApiClient.Capabilities.PostAsync(name, description);
         }
 
-        private void When_a_capability_is_deleted()
+        private async Task When_a_capability_is_deleted()
         {
-            throw new System.NotImplementedException();
+            await CapabilityApiClient.Capabilities.DeleteAsync(_capabilityDto.Id);
         }
 
-        private void Then_it_wont_be_in_the_capability_list()
+        private async Task Then_it_wont_be_in_the_capability_list()
         {
-            throw new System.NotImplementedException();
+            var capabilities = await CapabilityApiClient.Capabilities.GetAsync();
+            
+            Assert.All(capabilities.Items, dto => Assert.False(dto.Id.Equals(_capabilityDto.Id)));
         }
 
         private void And_a_event_will_be_published()

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading.Tasks;
+using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api;
+using Xunit;
+
+namespace CapabilityService.IntegrationTests.Features.Capabilities
+{
+    public class CapabilityDeletedScenario
+    {
+        [Fact]
+        public async Task CapabilityDeletedRecipe()
+        {
+            await Given_a_capability();
+            When_a_capability_is_deleted();
+            Then_it_wont_be_in_the_capability_list();
+            And_a_event_will_be_published();
+        }
+
+        private async Task Given_a_capability()
+        {
+            var name = "Integration-test-" + Guid.NewGuid().ToString();
+            var description = name;
+
+            await CapabilityApiClient.Capabilities.PostAsync(name, description);
+        }
+
+        private void When_a_capability_is_deleted()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private void Then_it_wont_be_in_the_capability_list()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        private void And_a_event_will_be_published()
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
@@ -26,6 +26,7 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities
             var description = name;
 
             _capabilityDto = await CapabilityApiClient.Capabilities.PostAsync(name, description);
+            await CapabilityApiClient.Capabilities.GetAsync(_capabilityDto.Id);
         }
 
         private async Task When_a_capability_is_deleted()

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/CapabilityDeletedScenario.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api;
 using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api.Model;
+using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Kafka;
 using Xunit;
 
 namespace CapabilityService.IntegrationTests.Features.Capabilities
@@ -15,13 +16,13 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities
         {
             await Given_a_capability();
             await When_a_capability_is_deleted();
-            Then_it_wont_be_in_the_capability_list();
+            await Then_it_wont_be_in_the_capability_list();
             And_a_event_will_be_published();
         }
 
         private async Task Given_a_capability()
         {
-            var name = "Integration-test-" + Guid.NewGuid().ToString().Substring(0,8);
+            var name = "Integration-test-" + Guid.NewGuid().ToString().Substring(0, 8);
             var description = name;
 
             _capabilityDto = await CapabilityApiClient.Capabilities.PostAsync(name, description);
@@ -35,13 +36,30 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities
         private async Task Then_it_wont_be_in_the_capability_list()
         {
             var capabilities = await CapabilityApiClient.Capabilities.GetAsync();
-            
+
             Assert.All(capabilities.Items, dto => Assert.False(dto.Id.Equals(_capabilityDto.Id)));
         }
 
         private void And_a_event_will_be_published()
         {
-            throw new System.NotImplementedException();
+            var capabilityKafkaClient = new CapabilityKafkaClient();
+          var events =  capabilityKafkaClient.GetUntilEventName(
+                WefoundTheEventWeWant, 
+                TimeSpan.FromSeconds(20)
+            );
+        }
+
+        public bool WefoundTheEventWeWant(dynamic @event)
+        {
+            if(@event == null) {return false;}
+            
+            if(
+                @event.eventName !="capability_deleted" || 
+                @event.payload.capabilityId != _capabilityDto.Id.ToString()
+            ) {return false;}
+
+
+            return true;
         }
     }
 }

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
@@ -2,48 +2,80 @@ using System;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api.Model;
 using Newtonsoft.Json;
 
 namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api
 {
     public static class CapabilityApiClient
     {
-         public static class Capabilities
-         {
-             private const string CapabilitiesUrl = "http://localhost:50900/api/v1/capabilities";
+        public static class Capabilities
+        {
+            private const string CapabilitiesUrl = "http://localhost:50900/api/v1/capabilities";
 
-             public static async Task GetAsync()
-             {
-                 
-             }
+            public static async Task<ItemsEnvelope<CapabilityDto>> GetAsync()
+            {
+                var uri = new Uri(CapabilitiesUrl);
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
 
-             public static async Task PostAsync(string name, string description)
-             {
-                 var payload = new
-                 {
+                var httpClient = new HttpClient();
+                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+
+                var contentString = await responseMessage.Content.ReadAsStringAsync();
+
+                var deserializeObject = JsonConvert.DeserializeObject<ItemsEnvelope<CapabilityDto>>(contentString);
+
+                return deserializeObject;
+            }
+
+            public static async Task<CapabilityDto> PostAsync(string name, string description)
+            {
+                var payload = new
+                {
                     name = name,
                     description = description
-                 };
+                };
 
 
-                 var uri = new Uri(CapabilitiesUrl);
-                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+                var uri = new Uri(CapabilitiesUrl);
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri);
 
-                 httpRequestMessage.Content = new StringContent(
-                     JsonConvert.SerializeObject(payload),
-                     Encoding.UTF8,
-                     "application/json"
-                 );
+                httpRequestMessage.Content = new StringContent(
+                    JsonConvert.SerializeObject(payload),
+                    Encoding.UTF8,
+                    "application/json"
+                );
 
 
-                 var httpClient = new HttpClient();
-                 var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+                var httpClient = new HttpClient();
+                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
 
-                 if (responseMessage.IsSuccessStatusCode == false)
-                 {
-                     throw new Exception(responseMessage.ReasonPhrase);
-                 }
-             }
-         } 
+                if (responseMessage.IsSuccessStatusCode == false)
+                {
+                    throw new Exception(responseMessage.ReasonPhrase);
+                }
+
+                var contentString = await responseMessage.Content.ReadAsStringAsync();
+
+                var deserializeObject = JsonConvert.DeserializeObject<CapabilityDto>(contentString);
+
+                return deserializeObject;
+            }
+
+            public static async Task DeleteAsync(Guid capabilityId)
+            {
+                var uri = new Uri(CapabilitiesUrl + "/" + capabilityId);
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, uri);
+
+                var httpClient = new HttpClient();
+                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+
+
+                if (responseMessage.IsSuccessStatusCode == false)
+                {
+                    throw new Exception(responseMessage.ReasonPhrase);
+                }
+            }
+        }
     }
 }

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
@@ -18,32 +18,20 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructur
                 var uri = new Uri(CapabilitiesUrl + "/" + capabilityId);
                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
 
-                var httpClient = new HttpClient();
-                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+                var responseMessage = await SendRequest(httpRequestMessage);
 
-                var contentString = await responseMessage.Content.ReadAsStringAsync();
-
-                if (responseMessage.IsSuccessStatusCode == false)
-                {
-                    throw new Exception(responseMessage.ReasonPhrase);
-                }
-                
-                var deserializeObject = JsonConvert.DeserializeObject<CapabilityDto>(contentString);
-                return deserializeObject;
+                return await DeserializeContent<CapabilityDto>(responseMessage);
             }
+
+
             public static async Task<ItemsEnvelope<CapabilityDto>> GetAsync()
             {
                 var uri = new Uri(CapabilitiesUrl);
                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
 
-                var httpClient = new HttpClient();
-                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+                var responseMessage = await SendRequest(httpRequestMessage);
 
-                var contentString = await responseMessage.Content.ReadAsStringAsync();
-
-                var deserializeObject = JsonConvert.DeserializeObject<ItemsEnvelope<CapabilityDto>>(contentString);
-
-                return deserializeObject;
+                return await DeserializeContent<ItemsEnvelope<CapabilityDto>>(responseMessage);
             }
 
             public static async Task<CapabilityDto> PostAsync(string name, string description)
@@ -64,35 +52,41 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructur
                     "application/json"
                 );
 
+                var responseMessage = await SendRequest(httpRequestMessage);
 
-                var httpClient = new HttpClient();
-                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
-
-                if (responseMessage.IsSuccessStatusCode == false)
-                {
-                    throw new Exception(responseMessage.ReasonPhrase);
-                }
-
-                var contentString = await responseMessage.Content.ReadAsStringAsync();
-
-                var deserializeObject = JsonConvert.DeserializeObject<CapabilityDto>(contentString);
-
-                return deserializeObject;
+                return await DeserializeContent<CapabilityDto>(responseMessage);
             }
+
 
             public static async Task DeleteAsync(Guid capabilityId)
             {
                 var uri = new Uri(CapabilitiesUrl + "/" + capabilityId);
                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, uri);
 
+                await SendRequest(httpRequestMessage);
+            }
+
+            
+            private static async Task<T> DeserializeContent<T>(HttpResponseMessage httpResponseMessage)
+            {
+                var contentString = await httpResponseMessage.Content.ReadAsStringAsync();
+
+
+                var deserializeObject = JsonConvert.DeserializeObject<T>(contentString);
+                return deserializeObject;
+            }
+
+            private static async Task<HttpResponseMessage> SendRequest(HttpRequestMessage httpRequestMessage)
+            {
                 var httpClient = new HttpClient();
                 var responseMessage = await httpClient.SendAsync(httpRequestMessage);
-
 
                 if (responseMessage.IsSuccessStatusCode == false)
                 {
                     throw new Exception(responseMessage.ReasonPhrase);
                 }
+
+                return responseMessage;
             }
         }
     }

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
@@ -13,6 +13,24 @@ namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructur
         {
             private const string CapabilitiesUrl = "http://localhost:50900/api/v1/capabilities";
 
+            public static async Task<CapabilityDto> GetAsync(Guid capabilityId)
+            {
+                var uri = new Uri(CapabilitiesUrl + "/" + capabilityId);
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, uri);
+
+                var httpClient = new HttpClient();
+                var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+
+                var contentString = await responseMessage.Content.ReadAsStringAsync();
+
+                if (responseMessage.IsSuccessStatusCode == false)
+                {
+                    throw new Exception(responseMessage.ReasonPhrase);
+                }
+                
+                var deserializeObject = JsonConvert.DeserializeObject<CapabilityDto>(contentString);
+                return deserializeObject;
+            }
             public static async Task<ItemsEnvelope<CapabilityDto>> GetAsync()
             {
                 var uri = new Uri(CapabilitiesUrl);

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/CapabilityApiClient.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api
+{
+    public static class CapabilityApiClient
+    {
+         public static class Capabilities
+         {
+             private const string CapabilitiesUrl = "http://localhost:50900/api/v1/capabilities";
+
+             public static async Task GetAsync()
+             {
+                 
+             }
+
+             public static async Task PostAsync(string name, string description)
+             {
+                 var payload = new
+                 {
+                    name = name,
+                    description = description
+                 };
+
+
+                 var uri = new Uri(CapabilitiesUrl);
+                 var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, uri);
+
+                 httpRequestMessage.Content = new StringContent(
+                     JsonConvert.SerializeObject(payload),
+                     Encoding.UTF8,
+                     "application/json"
+                 );
+
+
+                 var httpClient = new HttpClient();
+                 var responseMessage = await httpClient.SendAsync(httpRequestMessage);
+
+                 if (responseMessage.IsSuccessStatusCode == false)
+                 {
+                     throw new Exception(responseMessage.ReasonPhrase);
+                 }
+             }
+         } 
+    }
+}

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/Model/CapabilityDto.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/Model/CapabilityDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api.Model
+{
+    public class CapabilityDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string RootId { get; set; }
+    }
+}

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/Model/ItemsEnvelope.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Api/Model/ItemsEnvelope.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Api.Model
+{
+    public class ItemsEnvelope<T>
+       {
+           public T[] Items { get; }
+   
+           public ItemsEnvelope(IEnumerable<T> items)
+           {
+               Items = items.ToArray();
+           }
+       }
+}

--- a/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Kafka/CapabilityKafkaClient.cs
+++ b/src/CapabilityService.IntegrationTests/CapabilityService.IntegrationTests/Features/Capabilities/Infrastructure/Kafka/CapabilityKafkaClient.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using Confluent.Kafka;
+using Newtonsoft.Json;
+
+namespace CapabilityService.IntegrationTests.Features.Capabilities.Infrastructure.Kafka
+{
+    public class CapabilityKafkaClient
+    {
+        public List<dynamic> GetUntilEventName(
+            Func<dynamic, bool> weAreDone, 
+            TimeSpan timeOutForNewEvents
+        )
+        {
+            var consumerConfig = new ConsumerConfig
+            {
+                GroupId = "test-consumer-group-" + Guid.NewGuid(),
+                BootstrapServers = "localhost:9092",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+            };
+            
+            using (var consumer = new ConsumerBuilder<Ignore, string>(consumerConfig).Build())
+            {
+                consumer.Subscribe("build.capabilities");
+
+                try
+                {
+                    var cutOffTime = DateTime.Now.Add(timeOutForNewEvents);
+
+                    var events = new List<dynamic>();
+
+                    dynamic deserializeObject = null;
+                    do
+                    {
+                        var consumeResult = consumer.Consume(TimeSpan.FromMilliseconds(1));
+                        if (consumeResult != null)
+                        {
+                            deserializeObject = JsonConvert.DeserializeObject<dynamic>(consumeResult.Value);
+                            events.Add(deserializeObject);
+                            continue;
+                        }
+
+
+                        if (cutOffTime <= DateTime.Now)
+                        {
+                            throw new Exception(
+                                $"No new events has been posted before the deadline of Hour:Minute:Seconds: {timeOutForNewEvents:c} ");
+                        }
+                    } while (weAreDone(deserializeObject) == false);
+
+                    return events;
+                }
+                finally
+                {
+                    consumer.Close();
+                }
+            }
+        }
+    }
+}

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -26,7 +26,6 @@ namespace DFDS.CapabilityService.WebApi.Application
         {
             var capability = await _capabilityRepository.Get(id);
             capability.Delete();
-            _capabilityRepository.Remove(capability);
         }
 
 

--- a/src/CapabilityService.WebApi/Domain/Models/Capability.cs
+++ b/src/CapabilityService.WebApi/Domain/Models/Capability.cs
@@ -21,7 +21,8 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
         public IEnumerable<Membership> Memberships => _memberships;
         public IEnumerable<Context> Contexts => _contexts;
         
-        
+        public DateTime? Deleted { get; set; }
+
         public Capability(Guid id, string name, string rootId, string description, IEnumerable<Membership> memberships, IEnumerable<Context> contexts)
         {
             Id = id;
@@ -65,12 +66,14 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
 
         public void Delete()
         {
+            Deleted = DateTime.UtcNow;
             RaiseEvent(new CapabilityDeleted(
                 capabilityId: Id,
                 capabilityName: Name
             ));
         }
-        
+
+
         public void UpdateInfoFields(string newName, string newDescription)
         {
             Name = newName;

--- a/src/CapabilityService.WebApi/Domain/Repositories/ICapabilityRepository.cs
+++ b/src/CapabilityService.WebApi/Domain/Repositories/ICapabilityRepository.cs
@@ -10,7 +10,5 @@ namespace DFDS.CapabilityService.WebApi.Domain.Repositories
         Task<IEnumerable<Capability>> GetAll();
         Task Add(Capability capability);
         Task<Capability> Get(Guid id);
-
-        void Remove(Capability capability);
     }
 }

--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
@@ -43,10 +43,5 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
                 .SingleOrDefaultAsync(x => x.Id == id);
             return capability;
         }
-
-        public void Remove(Capability capability)
-        { 
-            _dbContext.Capabilities.Remove(capability);
-        }
     }
 }

--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
@@ -21,6 +21,7 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
         {
             return await _dbContext
                          .Capabilities
+                         .Where(c => c.Deleted == null)
                          .OrderBy(x => x.Name)
                          .Include(x => x.Memberships)
                          .Include(x => x.Contexts)


### PR DESCRIPTION
Capability is not deleted in database but gets a deleted property set.

Add a delete Capability integrationtest that ensures:
- The deleted capability is not returned by the API.
- A "capability_deleted" event is raised
