### PR TITLE
Simpler error handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 # Todo list
 
-/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs : 109 / 131
-replace Guid.TryCatch with a value object
-give propper response code if validation fails
-
 /src/CapabilityService.WebApi/Infrastructure/Messaging/Outbox.cs
 Rename variables to reflect types used
 
@@ -12,16 +8,15 @@ Remove SaveChangesAsync and let the transaction decorator take care of the save
 Note:
 We should probably look at implementing connection resilience our Db context @ https://docs.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency via execution strategies.
 
-src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs : 111
-Replace null check with not found exception try catch
-
 src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs : 35
 Use a capabilityName value type instead of initiating a Capability
 
 src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
 return a 422 if the given id can not be parsed to a guid.
 
-combine try catchs into a function
+/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs : 109 / 131
+replace Guid.TryCatch with a value object
+give propper response code if validation fails
 
 Look into enforcing the Transaction scope by allowing SaveAsync more places or abandom the concept for something else.
 This could be https://docs.microsoft.com/en-us/aspnet/mvc/overview/older-versions/getting-started-with-ef-5-using-mvc-4/implementing-the-repository-and-unit-of-work-patterns-in-an-asp-net-mvc-application

--- a/src/CapabilityService.Tests/Infrastructure/Api/TestCapabilitiesRoute.cs
+++ b/src/CapabilityService.Tests/Infrastructure/Api/TestCapabilitiesRoute.cs
@@ -353,11 +353,12 @@ namespace DFDS.CapabilityService.Tests.Infrastructure.Api
         {
             using (var builder = new HttpClientBuilder())
             {
+	            var dummyCapabilityId = Guid.NewGuid();
+
                 var client = builder
-                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException()))
+                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException(dummyCapabilityId)))
                     .Build();
 
-                var dummyCapabilityId = "foo";
                 var dummyMemberEmail = "bar";
 
                 var response = await client.DeleteAsync($@"api/v1/capabilities/{dummyCapabilityId}/members/{dummyMemberEmail}");
@@ -371,11 +372,12 @@ namespace DFDS.CapabilityService.Tests.Infrastructure.Api
         {
             using (var builder = new HttpClientBuilder())
             {
+	            var nonExistingCapabilityId = Guid.NewGuid();
+
                 var client = builder
-                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException()))
+                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException(nonExistingCapabilityId)))
                     .Build();
 
-                var nonExistingCapabilityId = "foo";
                 var dummyInput = "{}";
                 var response = await client.PostAsync($"api/v1/capabilities/{nonExistingCapabilityId}/members", new JsonContent(dummyInput));
 
@@ -408,12 +410,14 @@ namespace DFDS.CapabilityService.Tests.Infrastructure.Api
         {
             using (var builder = new HttpClientBuilder())
             {
+	            var nonExistingCapabilityId = Guid.NewGuid();
+	            
                 var client = builder
                     .WithService<ICapabilityApplicationService>(
-                        new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException()))
+                        new ErroneousCapabilityApplicationService(new CapabilityDoesNotExistException(nonExistingCapabilityId)))
                     .Build();
 
-                var nonExistingCapabilityId = "foo";
+                
                 var dummyInput = "{}";
                 var response = await client.PutAsync($"api/v1/capabilities/{nonExistingCapabilityId}", new JsonContent(dummyInput));
 

--- a/src/CapabilityService.Tests/Infrastructure/Api/TestCapabilitiesRoute.cs
+++ b/src/CapabilityService.Tests/Infrastructure/Api/TestCapabilitiesRoute.cs
@@ -335,12 +335,13 @@ namespace DFDS.CapabilityService.Tests.Infrastructure.Api
         {
             using (var builder = new HttpClientBuilder())
             {
+	            var dummyCapabilityId = Guid.NewGuid();
+	            var dummyMemberEmail = "bar";
+
                 var client = builder
-                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new NotMemberOfCapabilityException()))
+                    .WithService<ICapabilityApplicationService>(new ErroneousCapabilityApplicationService(new NotMemberOfCapabilityException(dummyCapabilityId,dummyMemberEmail)))
                     .Build();
 
-                var dummyCapabilityId = "foo";
-                var dummyMemberEmail = "bar";
 
                 var response = await client.DeleteAsync($@"api/v1/capabilities/{dummyCapabilityId}/members/{dummyMemberEmail}");
 

--- a/src/CapabilityService.Tests/TestDoubles/StubCapabilityApplicationService.cs
+++ b/src/CapabilityService.Tests/TestDoubles/StubCapabilityApplicationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Application;
+using DFDS.CapabilityService.WebApi.Domain.Exceptions;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 
 namespace DFDS.CapabilityService.Tests.TestDoubles
@@ -38,6 +39,11 @@ namespace DFDS.CapabilityService.Tests.TestDoubles
         public Task<Capability> GetCapability(Guid id)
         {
             var capability = _stubCapabilities.FirstOrDefault();
+
+            if (capability == null)
+            {
+	            throw new CapabilityDoesNotExistException(id);
+            }
             return Task.FromResult(capability);
         }
 

--- a/src/CapabilityService.Tests/TestDoubles/StubCapabilityRepository.cs
+++ b/src/CapabilityService.Tests/TestDoubles/StubCapabilityRepository.cs
@@ -33,7 +33,7 @@ namespace DFDS.CapabilityService.Tests.TestDoubles
             
             if (capability == null)
             {
-	            throw new CapabilityDoesNotExistException();
+	            throw new CapabilityDoesNotExistException(id);
             }
             
             return Task.FromResult(capability);

--- a/src/CapabilityService.Tests/TestDoubles/StubCapabilityRepository.cs
+++ b/src/CapabilityService.Tests/TestDoubles/StubCapabilityRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DFDS.CapabilityService.WebApi.Domain.Exceptions;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Domain.Repositories;
 
@@ -29,6 +30,12 @@ namespace DFDS.CapabilityService.Tests.TestDoubles
         public Task<Capability> Get(Guid id)
         {
             var capability = _capabilities.FirstOrDefault();
+            
+            if (capability == null)
+            {
+	            throw new CapabilityDoesNotExistException();
+            }
+            
             return Task.FromResult(capability);
         }
 

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -100,7 +100,7 @@ namespace DFDS.CapabilityService.WebApi.Application
             var existingTopicsWithSameName = await _topicRepository.FindBy(topicName);
             if (existingTopicsWithSameName.Any())
             {
-                throw new TopicAlreadyExistException($"A topic with the name \"{topicName}\" already exist.");
+                throw new TopicAlreadyExistException(topicName);
             }
 
             var topic = capability.AddTopic(topicName, topicDescription, isTopicPrivate);

--- a/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/CapabilityApplicationService.cs
@@ -59,22 +59,12 @@ namespace DFDS.CapabilityService.WebApi.Application
         {
             var capability = await _capabilityRepository.Get(capabilityId);
 
-            if (capability == null)
-            {
-                throw new CapabilityDoesNotExistException();
-            }
-
             capability.StartMembershipFor(memberEmail);
         }
 
         public async Task LeaveCapability(Guid capabilityId, string memberEmail)
         {
             var capability = await _capabilityRepository.Get(capabilityId);
-
-            if (capability == null)
-            {
-                throw new CapabilityDoesNotExistException();
-            }
 
             capability.StopMembershipFor(memberEmail);
         }
@@ -83,11 +73,6 @@ namespace DFDS.CapabilityService.WebApi.Application
         {
             var capability = await _capabilityRepository.Get(capabilityId);
 
-            if (capability == null)
-            {
-                throw new CapabilityDoesNotExistException();
-            }
-
             capability.AddContext(contextName);
         }
 
@@ -95,11 +80,7 @@ namespace DFDS.CapabilityService.WebApi.Application
             string awsRoleEmail)
         {
             var capability = await _capabilityRepository.Get(capabilityId);
-            if (capability == null)
-            {
-                throw new CapabilityDoesNotExistException();
-            }
-
+        
             var context = capability.Contexts.FirstOrDefault(c => c.Id == contextId);
             if (context == null)
             {
@@ -115,10 +96,6 @@ namespace DFDS.CapabilityService.WebApi.Application
         public async Task AddTopic(Guid capabilityId, string topicName, string topicDescription, bool isTopicPrivate)
         {
             var capability = await _capabilityRepository.Get(capabilityId);
-            if (capability == null)
-            {
-                throw new CapabilityDoesNotExistException();
-            }
 
             var existingTopicsWithSameName = await _topicRepository.FindBy(topicName);
             if (existingTopicsWithSameName.Any())

--- a/src/CapabilityService.WebApi/Application/TopicApplicationService.cs
+++ b/src/CapabilityService.WebApi/Application/TopicApplicationService.cs
@@ -61,7 +61,7 @@ namespace DFDS.CapabilityService.WebApi.Application
 
             if (isTopicNameTakenByAnotherTopic)
             {
-                throw new TopicAlreadyExistException($"A topic with the name \"{name}\" already exist.");
+                throw new TopicAlreadyExistException(name);
             }
 
             topic.Name = name;

--- a/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityDoesNotExistException.cs
+++ b/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityDoesNotExistException.cs
@@ -2,8 +2,11 @@
 
 namespace DFDS.CapabilityService.WebApi.Domain.Exceptions
 {
-    public class CapabilityDoesNotExistException : Exception
-    {
-        
-    }
+	public class CapabilityDoesNotExistException : Exception
+	{
+		public CapabilityDoesNotExistException(Guid capabilityId) : base(
+			$"Capability with id {capabilityId} could not be found.")
+		{
+		}
+	}
 }

--- a/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityWithSameNameExistException.cs
+++ b/src/CapabilityService.WebApi/Domain/Exceptions/CapabilityWithSameNameExistException.cs
@@ -4,6 +4,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Exceptions
 {
     public class CapabilityWithSameNameExistException : Exception
     {
-        
+        public CapabilityWithSameNameExistException(string name): base($"A capability with the name:'{name}' already exits, please give your capability a other name."){}
+	    
     }
 }

--- a/src/CapabilityService.WebApi/Domain/Exceptions/NotMemberOfCapabilityException.cs
+++ b/src/CapabilityService.WebApi/Domain/Exceptions/NotMemberOfCapabilityException.cs
@@ -4,6 +4,6 @@ namespace DFDS.CapabilityService.WebApi.Domain.Exceptions
 {
     public class NotMemberOfCapabilityException : Exception
     {
-        
+        public NotMemberOfCapabilityException(Guid capabilityId, string memberEmail): base($"Capability with id {capabilityId} does not have member \"{memberEmail}\"."){}
     }
 }

--- a/src/CapabilityService.WebApi/Domain/Exceptions/TopicAlreadyExistException.cs
+++ b/src/CapabilityService.WebApi/Domain/Exceptions/TopicAlreadyExistException.cs
@@ -4,7 +4,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Exceptions
 {
     public class TopicAlreadyExistException : Exception
     {
-        public TopicAlreadyExistException(string message) : base(message)
+        public TopicAlreadyExistException(string name) : base($"A topic with name \"{name}\" already exist.")
         {
             
         }

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityWithNoDuplicateNameFactory.cs
@@ -26,7 +26,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
 
             var capabilitiesWithSameName = existingCapabilities.Where(c => c.Name == name);
             
-            if(capabilitiesWithSameName.Any()) { throw  new CapabilityWithSameNameExistException();}
+            if(capabilitiesWithSameName.Any()) { throw  new CapabilityWithSameNameExistException(name);}
 
             return await _inner.Create(name, description);
         }

--- a/src/CapabilityService.WebApi/Domain/Models/Capability.cs
+++ b/src/CapabilityService.WebApi/Domain/Models/Capability.cs
@@ -95,7 +95,7 @@ namespace DFDS.CapabilityService.WebApi.Domain.Models
 
             if (membership == null)
             {
-                throw new NotMemberOfCapabilityException();
+                throw new NotMemberOfCapabilityException(Id,memberEmail);
             }
 
             _memberships.Remove(membership);

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -174,11 +174,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
 	                exception.Message
                 });
             }
-            catch (NotMemberOfCapabilityException)
+            catch (NotMemberOfCapabilityException exception)
             {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} does not have member \"{memberEmail}\"."
+	                exception.Message
                 });
             }
 

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -101,10 +101,10 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
                 return Ok(
                     value: dto
                 );
-            } catch (CapabilityDoesNotExistException) {
+            } catch (CapabilityDoesNotExistException exception) {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} could not be found."
+	                exception.Message
                 });                
             } catch (CapabilityValidationException tve) {
                 return BadRequest(new
@@ -167,11 +167,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
             {
                 await _capabilityApplicationService.LeaveCapability(capabilityId, memberEmail);
             }
-            catch (CapabilityDoesNotExistException)
+            catch (CapabilityDoesNotExistException exception)
             {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} could not be found."
+	                exception.Message
                 });
             }
             catch (NotMemberOfCapabilityException)
@@ -195,11 +195,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
             {
                 await _capabilityApplicationService.AddContext(capabilityId, input.Name);
             }
-            catch (CapabilityDoesNotExistException)
+            catch (CapabilityDoesNotExistException exception)
             {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} could not be found."
+	                exception.Message
                 });
             }
 
@@ -216,11 +216,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
             {
                 await _capabilityApplicationService.AddTopic(capabilityId, input.Name, input.Description, input.IsPrivate);
             }
-            catch (CapabilityDoesNotExistException)
+            catch (CapabilityDoesNotExistException exception)
             {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} could not be found."
+	                exception.Message
                 });
             }
             catch (TopicAlreadyExistException)

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Application;
@@ -70,11 +70,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
                     Message = tve.Message
                 });
             }
-            catch (CapabilityWithSameNameExistException)
+            catch (CapabilityWithSameNameExistException exception)
             {
                 return Conflict(new
                 {
-                    Message = $"A capability with the name:'{input.Name}' already exits, please give your capability a other name."
+	                exception.Message
                 });
             }
             

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -146,11 +146,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
             {
                 await _capabilityApplicationService.JoinCapability(capabilityId, input.Email);
             }
-            catch (CapabilityDoesNotExistException)
+            catch (CapabilityDoesNotExistException exception)
             {
                 return NotFound(new
                 {
-                    Message = $"Capability with id {id} could not be found."
+	                exception.Message
                 });
             }
 

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Application;
@@ -223,11 +223,11 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
 	                exception.Message
                 });
             }
-            catch (TopicAlreadyExistException)
+            catch (TopicAlreadyExistException exception)
             {
                 return Conflict(new
                 {
-                    Message = $"A topic with name \"{input.Name}\" already exist."
+	                exception.Message
                 });
             }
 

--- a/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Api/CapabilityController.cs
@@ -4,234 +4,212 @@ using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Application;
 using DFDS.CapabilityService.WebApi.Domain.Exceptions;
 using DFDS.CapabilityService.WebApi.Infrastructure.Api.DTOs;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DFDS.CapabilityService.WebApi.Infrastructure.Api
 {
-    [ApiController]
-    [Route("api/v1/capabilities")]
-    public class CapabilityController : ControllerBase
-    {
-        private readonly ICapabilityApplicationService _capabilityApplicationService;
+	[ApiController]
+	[Route("api/v1/capabilities")]
+	public class CapabilityController : ControllerBase
+	{
+		private readonly ICapabilityApplicationService _capabilityApplicationService;
 
-        public CapabilityController(ICapabilityApplicationService capabilityApplicationService)
-        {
-            _capabilityApplicationService = capabilityApplicationService;
-        }
+		public CapabilityController(ICapabilityApplicationService capabilityApplicationService)
+		{
+			_capabilityApplicationService = capabilityApplicationService;
+		}
 
-        [HttpGet("")]
-        public async Task<IActionResult> GetAllCapabilities()
-        {
-            var capabilities = await _capabilityApplicationService.GetAllCapabilities();
+		[HttpGet("")]
+		public async Task<IActionResult> GetAllCapabilities()
+		{
+			var capabilities = await _capabilityApplicationService.GetAllCapabilities();
 
-            return Ok(new CapabilityResponse
-            {
-                Items = capabilities
-                        .Select(Capability.Create)
-                        .ToArray()
-            });
-        }
+			return Ok(new CapabilityResponse
+			{
+				Items = capabilities
+					.Select(Capability.Create)
+					.ToArray()
+			});
+		}
 
-        [HttpGet("{id}")]
-        public async Task<IActionResult> GetCapability(string id)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
+		[HttpGet("{id}")]
+		public async Task<IActionResult> GetCapability(string id)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
 
-            var capability = await _capabilityApplicationService.GetCapability(capabilityId);
+			CapabilityDetails dto;
+			try
+			{
+				var capability = await _capabilityApplicationService.GetCapability(capabilityId);
 
-            if (capability == null)
-            {
-                return NotFound(new
-                {
-                    Message = $"A capability with id \"{id}\" could not be found."
-                });
-            }
-
-            var topics = await _capabilityApplicationService.GetTopicsForCapability(capabilityId);
-            var dto = CapabilityDetails.Create(capability, topics);
-
-            return Ok(dto);
-        }
-
-        [HttpPost("")]
-        public async Task<IActionResult> CreateCapability(CapabilityInput input)
-        {
-            Domain.Models.Capability capability;
-            try
-            {
-                capability = await _capabilityApplicationService.CreateCapability(input.Name, input.Description);
-            }
-            catch (CapabilityValidationException tve)
-            {
-                return BadRequest(new
-                {
-                    Message = tve.Message
-                });
-            }
-            catch (CapabilityWithSameNameExistException exception)
-            {
-                return Conflict(new
-                {
-	                exception.Message
-                });
-            }
-            
-            var dto = Capability.Create(capability);
-
-            return CreatedAtAction(
-                actionName: nameof(GetCapability),
-                routeValues: new {id = capability.Id},
-                value: dto
-            );
-        }
-
-        [HttpPut("{id}")]
-        public async Task<IActionResult> UpdateCapability(string id, [FromBody] CapabilityInput input)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
-
-            try
-            {
-                var capability = await _capabilityApplicationService.UpdateCapability(capabilityId, input.Name, input.Description);
-                var dto = Capability.Create(capability);
-
-                return Ok(
-                    value: dto
-                );
-            } catch (CapabilityDoesNotExistException exception) {
-                return NotFound(new
-                {
-	                exception.Message
-                });                
-            } catch (CapabilityValidationException tve) {
-                return BadRequest(new
-                {
-                    Message = tve.Message
-                });
-            }
-        }
-        
-        
-        [HttpDelete("{id}")]
-        public async Task<IActionResult> DeleteCapability(string id)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
-
-            var capability = await _capabilityApplicationService.GetCapability(capabilityId);
-
-            if (capability == null)
-            {
-                return NotFound(new
-                {
-                    Message = $"A capability with id \"{id}\" could not be found."
-                });
-            }
+				var topics = await _capabilityApplicationService.GetTopicsForCapability(capabilityId);
+				dto = CapabilityDetails.Create(capability, topics);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
 
 
-            await _capabilityApplicationService.DeleteCapability(capabilityId);
-            return Ok();
-        }
-        
-        [HttpPost("{id}/members")]
-        public async Task<IActionResult> AddMemberToCapability(string id, [FromBody] MemberInput input)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
+			return Ok(dto);
+		}
 
-            try
-            {
-                await _capabilityApplicationService.JoinCapability(capabilityId, input.Email);
-            }
-            catch (CapabilityDoesNotExistException exception)
-            {
-                return NotFound(new
-                {
-	                exception.Message
-                });
-            }
+		[HttpPost("")]
+		public async Task<IActionResult> CreateCapability(CapabilityInput input)
+		{
+			Domain.Models.Capability capability;
+			Capability dto;
+			try
+			{
+				capability = await _capabilityApplicationService.CreateCapability(input.Name, input.Description);
 
-            return Ok();
-        }
+				dto = Capability.Create(capability);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
 
-        [HttpDelete("{id}/members/{memberEmail}")]
-        public async Task<IActionResult> RemoveMemberFromCapability([FromRoute] string id, [FromRoute] string memberEmail)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
+			return CreatedAtAction(
+				actionName: nameof(GetCapability),
+				routeValues: new {id = capability.Id},
+				value: dto
+			);
+		}
 
-            try
-            {
-                await _capabilityApplicationService.LeaveCapability(capabilityId, memberEmail);
-            }
-            catch (CapabilityDoesNotExistException exception)
-            {
-                return NotFound(new
-                {
-	                exception.Message
-                });
-            }
-            catch (NotMemberOfCapabilityException exception)
-            {
-                return NotFound(new
-                {
-	                exception.Message
-                });
-            }
+		[HttpPut("{id}")]
+		public async Task<IActionResult> UpdateCapability(string id, [FromBody] CapabilityInput input)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
 
-            return Ok();
-        }
-        
-        [HttpPost("{id}/contexts")]
-        public async Task<IActionResult> AddContextToCapability(string id, [FromBody] ContextInput input)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
+			try
+			{
+				var capability =
+					await _capabilityApplicationService.UpdateCapability(capabilityId, input.Name, input.Description);
+				var dto = Capability.Create(capability);
 
-            try
-            {
-                await _capabilityApplicationService.AddContext(capabilityId, input.Name);
-            }
-            catch (CapabilityDoesNotExistException exception)
-            {
-                return NotFound(new
-                {
-	                exception.Message
-                });
-            }
+				return Ok(
+					value: dto
+				);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
+		}
 
-            return Ok();
-        }
 
-        [HttpPost("{id}/topics")]
-        public async Task<IActionResult> AddTopicToCapability(string id, [FromBody] TopicInput input)
-        {
-            var capabilityId = Guid.Empty;
-            Guid.TryParse(id, out capabilityId);
+		[HttpDelete("{id}")]
+		public async Task<IActionResult> DeleteCapability(string id)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
 
-            try
-            {
-                await _capabilityApplicationService.AddTopic(capabilityId, input.Name, input.Description, input.IsPrivate);
-            }
-            catch (CapabilityDoesNotExistException exception)
-            {
-                return NotFound(new
-                {
-	                exception.Message
-                });
-            }
-            catch (TopicAlreadyExistException exception)
-            {
-                return Conflict(new
-                {
-	                exception.Message
-                });
-            }
+			try
+			{
+				await _capabilityApplicationService.DeleteCapability(capabilityId);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
 
-            return Ok();
-        }
-    }
+
+			return Ok();
+		}
+
+		[HttpPost("{id}/members")]
+		public async Task<IActionResult> AddMemberToCapability(string id, [FromBody] MemberInput input)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
+
+			try
+			{
+				await _capabilityApplicationService.JoinCapability(capabilityId, input.Email);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
+
+			return Ok();
+		}
+
+		[HttpDelete("{id}/members/{memberEmail}")]
+		public async Task<IActionResult> RemoveMemberFromCapability([FromRoute] string id,
+			[FromRoute] string memberEmail)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
+
+			try
+			{
+				await _capabilityApplicationService.LeaveCapability(capabilityId, memberEmail);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
+
+			return Ok();
+		}
+
+		[HttpPost("{id}/contexts")]
+		public async Task<IActionResult> AddContextToCapability(string id, [FromBody] ContextInput input)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
+
+			try
+			{
+				await _capabilityApplicationService.AddContext(capabilityId, input.Name);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
+
+			return Ok();
+		}
+
+		[HttpPost("{id}/topics")]
+		public async Task<IActionResult> AddTopicToCapability(string id, [FromBody] TopicInput input)
+		{
+			var capabilityId = Guid.Empty;
+			Guid.TryParse(id, out capabilityId);
+
+			try
+			{
+				await _capabilityApplicationService.AddTopic(capabilityId, input.Name, input.Description,
+					input.IsPrivate);
+			}
+			catch (Exception exception)
+			{
+				return ExceptionToStatusCode(exception);
+			}
+
+
+			return Ok();
+		}
+
+		public ActionResult ExceptionToStatusCode(Exception exception)
+		{
+			switch (exception)
+			{
+				case CapabilityDoesNotExistException _:
+				case NotMemberOfCapabilityException _:
+					return NotFound(new {exception.Message});
+				case CapabilityValidationException _:
+					return BadRequest(new {exception.Message});
+				case CapabilityWithSameNameExistException _:
+				case TopicAlreadyExistException _:
+					return Conflict(new {exception.Message});
+				default:
+					throw exception;
+			}
+		}
+	}
 }

--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
@@ -45,7 +45,7 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
             
             if (capability == null)
             {
-	            throw new CapabilityDoesNotExistException();
+	            throw new CapabilityDoesNotExistException(id);
             }
             
             return capability;

--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityRepository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DFDS.CapabilityService.WebApi.Domain.Exceptions;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Domain.Repositories;
 using Microsoft.EntityFrameworkCore;
@@ -41,6 +42,12 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
                 .Include(x => x.Memberships)
                 .Include(x => x.Contexts)
                 .SingleOrDefaultAsync(x => x.Id == id);
+            
+            if (capability == null)
+            {
+	            throw new CapabilityDoesNotExistException();
+            }
+            
             return capability;
         }
     }


### PR DESCRIPTION
Autoformat messed up what have changed... Sorry :(

The goal is to move translation of exceptions into one place to ensure the same response codes are used for a given exception no matter what API endpoint you touch.