### PR TITLE
add ValueObject

### DIFF
--- a/src/CapabilityService.Tests/Domain/Models/TestValueObject.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestValueObject.cs
@@ -1,0 +1,165 @@
+using System;
+using Xunit;
+
+namespace DFDS.CapabilityService.Tests.Domain.Models
+{
+	public class TestValueObject
+	{
+		[Fact]
+		public void Equals_is_false_if_one_attribute_is_not_the_same()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.NewGuid()
+			);
+
+			var valueObjectTestSubject02 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			Assert.NotEqual(
+				valueObjectTestSubject01,
+				valueObjectTestSubject02
+			);
+		}
+
+		[Fact]
+		public void Equals_is_true_if_all_attributes_are_the_same()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			var valueObjectTestSubject02 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			Assert.Equal(
+				valueObjectTestSubject01,
+				valueObjectTestSubject02
+			);
+		}
+
+		[Fact]
+		public void Equals_is_false_if_one_is_null()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.NewGuid()
+			);
+
+			ValueObjectTestSubject valueObjectTestSubject02 = null;
+
+			Assert.False(valueObjectTestSubject01.Equals(valueObjectTestSubject02));
+		}
+
+		[Fact]
+		public void Equals_is_false_one_is_different_type()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.NewGuid()
+			);
+
+			string valueObjectTestSubject02 = "baa";
+
+			Assert.False(valueObjectTestSubject01.Equals(valueObjectTestSubject02));
+		}
+
+		[Fact]
+		public void Not_equal_operator_returns_false__if_both_is_null()
+		{
+			ValueObjectTestSubject valueObjectTestSubject01 = null;
+			ValueObjectTestSubject valueObjectTestSubject02 = null;
+
+			Assert.False(valueObjectTestSubject01 != valueObjectTestSubject02);
+		}
+
+		[Fact]
+		public void Not_equal_operator_returns_true_if_one_is_null()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			ValueObjectTestSubject valueObjectTestSubject02 = null;
+
+			Assert.True(valueObjectTestSubject01 != valueObjectTestSubject02);
+		}
+
+		[Fact]
+		public void Not_equal_operator_returns_false_if_both_has_same_properties()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			var valueObjectTestSubject02 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+
+			Assert.False(valueObjectTestSubject01 != valueObjectTestSubject02);
+		}
+
+
+		[Fact]
+		public void GetHashCode_returns_same_number_if_both_has_same_properties()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+			var valueObjectTestSubject02 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+
+			Assert.Equal(
+				valueObjectTestSubject01.GetHashCode(),
+				valueObjectTestSubject02.GetHashCode()
+			);
+		}
+		
+		[Fact]
+		public void GetHashCode_returns_different_number_if_one_property_is_different()
+		{
+			var valueObjectTestSubject01 = new ValueObjectTestSubject(
+				"baa",
+				1337,
+				Guid.Empty
+			);
+
+			var valueObjectTestSubject02 = new ValueObjectTestSubject(
+				"foo",
+				1337,
+				Guid.Empty
+			);
+
+
+			Assert.NotEqual(
+				valueObjectTestSubject01.GetHashCode(),
+				valueObjectTestSubject02.GetHashCode()
+			);
+		}
+	}
+}

--- a/src/CapabilityService.Tests/Domain/Models/ValueObjectTestSubject.cs
+++ b/src/CapabilityService.Tests/Domain/Models/ValueObjectTestSubject.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using DFDS.CapabilityService.WebApi.Domain.Models;
+
+namespace DFDS.CapabilityService.Tests.Domain.Models
+{
+	public class ValueObjectTestSubject : ValueObject
+	{
+		public string Value1 { get; }
+		public int Value2 { get; }
+		public Guid Value3 { get; }
+
+		public ValueObjectTestSubject(string value1, int value2, Guid value3)
+		{
+			Value1 = value1;
+			Value2 = value2;
+			Value3 = value3;
+		}
+		protected override IEnumerable<object> GetEqualityComponents()
+		{
+			yield return Value1;
+			yield return Value2;
+			yield return Value3;
+		}
+	}
+}

--- a/src/CapabilityService.WebApi/Domain/Models/ValueObject.cs
+++ b/src/CapabilityService.WebApi/Domain/Models/ValueObject.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DFDS.CapabilityService.WebApi.Domain.Models
+{
+	public abstract class ValueObject
+	{
+		protected abstract IEnumerable<object> GetEqualityComponents();
+
+		public override bool Equals(object obj)
+		{
+			if (obj == null || GetType() != obj.GetType())
+				return false;
+
+			var valueObject = (ValueObject)obj;
+
+			return GetEqualityComponents()
+				.SequenceEqual(
+					valueObject.GetEqualityComponents()
+				);
+		}
+
+		public override int GetHashCode()
+		{
+			return GetEqualityComponents()
+				.Aggregate(1, (current, obj) =>
+				{
+					unchecked
+					{
+						return current * 23 + (obj?.GetHashCode() ?? 0);
+					}
+				});
+		}
+
+		public static bool operator ==(ValueObject a, ValueObject b)
+		{
+			if (ReferenceEquals(a, null) && ReferenceEquals(b, null))
+				return true;
+
+			if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+				return false;
+
+			return a.Equals(b);
+		}
+
+		public static bool operator !=(ValueObject a, ValueObject b)
+		{
+			return !(a == b);
+		}
+	}
+}


### PR DESCRIPTION
Reason for work:
CapabilityName property of Capability can benefit from being a value object.   


Stolen from (Vladimir Khorikov):
https://enterprisecraftsmanship.com/posts/value-object-better-implementation/
Chose it over (Microsoft):
https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/implement-value-objects

Reasons: 
* I find it easier to understand Vladimirs equals. 
* Vladimirs overloads the != and == operators.

Other notes:
The GetAtomicValues & GetEqualityComponents are the same. Thou you can argue that the Values may not be atomic if you nest value objects.

