### PR TITLE
- Disable basic auth

### DIFF
--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -6,8 +6,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: PathPrefixStrip
-    traefik.ingress.kubernetes.io/auth-type: basic
-    traefik.ingress.kubernetes.io/auth-secret: capabilityservice-basic-authentication-credentials
+    #traefik.ingress.kubernetes.io/auth-type: basic
+    #traefik.ingress.kubernetes.io/auth-secret: capabilityservice-basic-authentication-credentials
 spec:
   rules:
     - host: api.hellman.oxygen.dfds.cloud

--- a/k8s/ingress.yml
+++ b/k8s/ingress.yml
@@ -6,8 +6,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: traefik
     traefik.frontend.rule.type: PathPrefixStrip
-    #traefik.ingress.kubernetes.io/auth-type: basic
-    #traefik.ingress.kubernetes.io/auth-secret: capabilityservice-basic-authentication-credentials
 spec:
   rules:
     - host: api.hellman.oxygen.dfds.cloud


### PR DESCRIPTION
Disabling basic auth on traefik as it interferes with oauth middleware in the API's.