### PR TITLE
Fix .NET 3.1 DB breaking change

### DIFF
--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityServiceDbContext.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityServiceDbContext.cs
@@ -43,6 +43,9 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
             modelBuilder.Entity<Membership>(cfg =>
             {
                 cfg.ToTable("Membership");
+
+                cfg.Property(e => e.Id).ValueGeneratedNever();
+
                 cfg.OwnsOne(x => x.Member)
                    .Property(x => x.Email)
                    .HasColumnName("MemberEmail");


### PR DESCRIPTION
Due to how we use Membership during its creation, it is after the 2.2 -> 3.1 upgrade now assumed that it is a database row being updated, rather than inserted

https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#detectchanges-honors-store-generated-key-values

Apologies for the annoying diff(CRLF back to LF)

The only line changed is somewhere around line 46

`cfg.Property(e => e.Id).ValueGeneratedNever();`