### PR TITLE
fix EntityFrameworkCore: add ValueGeneratedNever to table Context

### DIFF
--- a/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityServiceDbContext.cs
+++ b/src/CapabilityService.WebApi/Infrastructure/Persistence/CapabilityServiceDbContext.cs
@@ -37,15 +37,14 @@ namespace DFDS.CapabilityService.WebApi.Infrastructure.Persistence
             modelBuilder.Entity<Context>(cfg =>
             {
                 cfg.ToTable("Context");
+                cfg.Property(e => e.Id).ValueGeneratedNever();
                 cfg.Property(x => x.Name).HasColumnName("Name");
             });
 
             modelBuilder.Entity<Membership>(cfg =>
             {
                 cfg.ToTable("Membership");
-
                 cfg.Property(e => e.Id).ValueGeneratedNever();
-
                 cfg.OwnsOne(x => x.Member)
                    .Property(x => x.Email)
                    .HasColumnName("MemberEmail");


### PR DESCRIPTION
Same issue as: https://github.com/dfds/capability-service/commit/b0e8f582a659de61c2e758a04b868badabee9f83

EF will not attempt to generate a id for contexts:
https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.metadata.builders.propertybuilder-1.valuegeneratednever?view=efcore-3.1

Because we create the id our self. 