### PR TITLE
CapSvc: Extend metrics to cover Topics imbalance

### DIFF
--- a/db/migrations/20200403150052_add_creation_timestamp_and_last_modified_timestamp_to_topic_table.sql
+++ b/db/migrations/20200403150052_add_creation_timestamp_and_last_modified_timestamp_to_topic_table.sql
@@ -1,0 +1,7 @@
+-- 2020-04-03 15:00:52 : add_creation_timestamp_and_last_modified_timestamp_to_topic_table
+
+ALTER TABLE public."KafkaTopic"
+ADD COLUMN "Created" timestamp;
+
+ALTER TABLE public."KafkaTopic"
+ADD COLUMN "LastModified" timestamp;

--- a/db/seed/KafkaTopic.csv
+++ b/db/seed/KafkaTopic.csv
@@ -1,3 +1,3 @@
-Id,Name,Description,CapabilityId,Partitions
-392e92d7-ab43-47e2-b7b7-0cdecea833d1,Capability-A.topic-01,The first topic,0d03e3ad-2118-46b7-970e-0ca87b59a202,3
-6e07d7ac-1a88-44b5-8c94-ef8d54db03d1,Capability-A.topic-02,The second topic,0d03e3ad-2118-46b7-970e-0ca87b59a202,12
+Id,Name,Description,CapabilityId,Partitions,Created,LastModified
+629c8960-e7c0-4fd5-b08b-9ad1907e0c86,Capability-A.topic-01,The first topic,0d03e3ad-2118-46b7-970e-0ca87b59a202,3,2020-04-01 19:10:25-07,2020-04-01 19:10:25-07
+F7388B32-A5DF-4E73-B41A-BD033C7662CB,Capability-A.topic-02,The second topic,0d03e3ad-2118-46b7-970e-0ca87b59a202,12,2020-03-28 19:10:25-07,2020-04-01 19:10:25-07

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,6 +26,7 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - CAPABILITY_SERVICE_BASIC_AUTH_USER_AND_PASS=user:thisisindeedapassword
       - KAFKAJANITOR_API_ENDPOINT=http://kafka-janitor:5000
+#      - CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS=5
 
   kafka:
     environment:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -25,10 +25,8 @@ services:
       - "ASPNETCORE_URLS=http://+:50900"
       - ASPNETCORE_ENVIRONMENT=Development
       - CAPABILITY_SERVICE_BASIC_AUTH_USER_AND_PASS=user:thisisindeedapassword
-    volumes:
-      - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
-      - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
+      - KAFKAJANITOR_API_ENDPOINT=http://kafka-janitor:5000
 
- kafka:
+  kafka:
     environment:
       - "ADVERTISED_HOST=kafka"

--- a/src/CapabilityService.WebApi/Features/Kafka/Domain/Models/Topic.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Domain/Models/Topic.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Events;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Exceptions;
@@ -12,7 +13,9 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 			Guid capabilityId,
 			TopicName name,
 			string description,
-			int partitions
+			int partitions,
+			DateTime created,
+			DateTime lastModified
 		)
 		{
 			Id = id;
@@ -20,6 +23,8 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 			Name = name;
 			Description = description;
 			Partitions = partitions;
+			Created = created;
+			LastModified = lastModified;
 		}
 
 		public static Topic Create(
@@ -46,7 +51,9 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 				capabilityId: capabilityId,
 				name: TopicName.Create(capabilityName, name),
 				description: description,
-				partitions: partitions
+				partitions: partitions,
+				created: DateTime.Now,
+				lastModified: DateTime.UtcNow
 			);
 
 			topic.RaiseEvent(new TopicCreated(topic));
@@ -60,13 +67,17 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 		public string Description { get; private set; }
 		public Guid CapabilityId { get; private set; }
 		public int Partitions { get; private set; }
+		public DateTime Created { get; set; }
+		public DateTime LastModified { get; set; }
 
 		public static Topic FromSimpleTypes(
 			string id,
 			string capabilityId,
 			string name,
 			string description,
-			int partitions
+			int partitions,
+			DateTime created,
+			DateTime lastModified
 		)
 		{
 			return new Topic(
@@ -74,7 +85,9 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 				Guid.Parse(capabilityId),
 				TopicName.FromString(name),
 				description,
-				partitions
+				partitions,
+				created,
+				lastModified
 			);
 		}
 	}

--- a/src/CapabilityService.WebApi/Features/Kafka/Domain/Models/Topic.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Domain/Models/Topic.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using DFDS.CapabilityService.WebApi.Domain.Models;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Events;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Exceptions;
@@ -23,8 +22,8 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 			Name = name;
 			Description = description;
 			Partitions = partitions;
-			Created = created;
-			LastModified = lastModified;
+			Created = created.ToUniversalTime();
+			LastModified = lastModified.ToUniversalTime();
 		}
 
 		public static Topic Create(
@@ -52,7 +51,7 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 				name: TopicName.Create(capabilityName, name),
 				description: description,
 				partitions: partitions,
-				created: DateTime.Now,
+				created: DateTime.UtcNow,
 				lastModified: DateTime.UtcNow
 			);
 
@@ -67,8 +66,8 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models
 		public string Description { get; private set; }
 		public Guid CapabilityId { get; private set; }
 		public int Partitions { get; private set; }
-		public DateTime Created { get; set; }
-		public DateTime LastModified { get; set; }
+		public DateTime Created { get; private set; }
+		public DateTime LastModified { get; private set; }
 
 		public static Topic FromSimpleTypes(
 			string id,

--- a/src/CapabilityService.WebApi/Features/Kafka/Domain/Services/ITopicDomainService.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Domain/Services/ITopicDomainService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Models;
 
@@ -6,5 +7,6 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Services
 	public interface ITopicDomainService
 	{
 		Task CreateTopic(Topic topic, bool dryRun);
+		Task<IEnumerable<Topic>> GetAllTopics();
 	}
 }

--- a/src/CapabilityService.WebApi/Features/Kafka/Domain/Services/TopicDomainService.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Domain/Services/TopicDomainService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Exceptions;
@@ -24,6 +25,11 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Services
 			if(dryRun) return;
 			
 			await _topicRepository.AddAsync(topic);
+		}
+
+		public async Task<IEnumerable<Topic>> GetAllTopics()
+		{
+			return await _topicRepository.GetAllAsync();
 		}
 	}
 }

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/DependencyInjection.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/DependencyInjection.cs
@@ -1,11 +1,14 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 {
 	public static class DependencyInjection
 	{
-		public static void AddTopicMetrics(this IServiceCollection services)
+		public static void AddTopicMetrics(this IServiceCollection services, IConfiguration configuration)
 		{
+			services.AddOptions<TopicOverseerOptions>();
+			services.Configure<TopicOverseerOptions>(configuration);
 			services.AddHostedService<TopicOverseer>();
 		}
 	}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/DependencyInjection.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/DependencyInjection.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
+{
+	public static class DependencyInjection
+	{
+		public static void AddTopicMetrics(this IServiceCollection services)
+		{
+			services.AddHostedService<TopicOverseer>();
+		}
+	}
+}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Services;
+using KafkaJanitor.RestClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
+{
+	public class TopicOverseer : BackgroundService
+	{
+		private readonly IServiceProvider _serviceProvider;
+
+		public TopicOverseer(IServiceProvider serviceProvider)
+		{
+			_serviceProvider = serviceProvider;
+		}
+
+		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+		{
+			Console.WriteLine("Starting TopicOverseer");
+
+			var topicsEquality = Prometheus.Metrics.CreateGauge("features_topics_equality",
+				"If there are more topics in CC than capsvc, then it'll go in minus. If there are less topics in CC than capsvc, then it'll go in surplus. If everythin is fine, then it'll be zero.");
+			topicsEquality.Set(0);
+
+			while (!stoppingToken.IsCancellationRequested)
+			{
+				try
+				{
+					using (var scope = _serviceProvider.CreateScope())
+					{
+						var topicDomainService = scope.ServiceProvider.GetRequiredService<ITopicDomainService>();
+						var kafkaJanitorRestClient = scope.ServiceProvider.GetRequiredService<IRestClient>();
+						
+						var capSvcTopics = await topicDomainService.GetAllTopics();
+						var connectedTopics = await kafkaJanitorRestClient.Topics.GetAllAsync();
+						topicsEquality.Set(capSvcTopics.Count() - connectedTopics.Count());
+					}
+				}
+				catch (Exception err)
+				{
+					Log.Error(err.Message);
+				}
+				await Task.Delay(TimeSpan.FromMinutes(4), stoppingToken);
+			}
+		}
+	}
+}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
@@ -13,10 +13,14 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 	public class TopicOverseer : BackgroundService
 	{
 		private readonly IServiceProvider _serviceProvider;
+		private readonly TopicOverseerOptions _topicOverseerOptions;
+		private double _loop_delay; 
 
-		public TopicOverseer(IServiceProvider serviceProvider)
+		public TopicOverseer(IServiceProvider serviceProvider, TopicOverseerOptions options)
 		{
 			_serviceProvider = serviceProvider;
+			_topicOverseerOptions = options;
+			_loop_delay = _topicOverseerOptions.CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS != null ? Double.Parse(_topicOverseerOptions.CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS) : 60 * 4;
 		}
 
 		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -24,7 +28,7 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 			Console.WriteLine("Starting TopicOverseer");
 
 			var topicsEquality = Prometheus.Metrics.CreateGauge("features_topics_equality",
-				"If there are more topics in CC than capsvc, then it'll go in minus. If there are less topics in CC than capsvc, then it'll go in surplus. If everythin is fine, then it'll be zero.");
+				"If there are more topics in CC than capsvc, then it'll go in minus. If there are less topics in CC than capsvc, then it'll go in surplus. If everything is fine, then it'll be zero.");
 			topicsEquality.Set(0);
 
 			while (!stoppingToken.IsCancellationRequested)
@@ -45,7 +49,7 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 				{
 					Log.Error(err.Message);
 				}
-				await Task.Delay(TimeSpan.FromMinutes(4), stoppingToken);
+				await Task.Delay(TimeSpan.FromSeconds(_loop_delay), stoppingToken);
 			}
 		}
 	}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseer.cs
@@ -6,6 +6,7 @@ using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Services;
 using KafkaJanitor.RestClient;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 using Serilog;
 
 namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
@@ -13,14 +14,14 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 	public class TopicOverseer : BackgroundService
 	{
 		private readonly IServiceProvider _serviceProvider;
-		private readonly TopicOverseerOptions _topicOverseerOptions;
+		private readonly IOptions<TopicOverseerOptions> _topicOverseerOptions;
 		private double _loop_delay; 
 
-		public TopicOverseer(IServiceProvider serviceProvider, TopicOverseerOptions options)
+		public TopicOverseer(IServiceProvider serviceProvider, IOptions<TopicOverseerOptions> options)
 		{
 			_serviceProvider = serviceProvider;
 			_topicOverseerOptions = options;
-			_loop_delay = _topicOverseerOptions.CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS != null ? Double.Parse(_topicOverseerOptions.CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS) : 60 * 4;
+			_loop_delay = _topicOverseerOptions.Value.CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS != null ? Double.Parse(_topicOverseerOptions.Value.CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS) : 60 * 4;
 		}
 
 		protected override async Task ExecuteAsync(CancellationToken stoppingToken)

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseerOptions.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseerOptions.cs
@@ -4,14 +4,14 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
 {
 	public class TopicOverseerOptions
 	{
-		public string CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS { get; set; }
+		public string CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS { get; set; }
 		
 		public TopicOverseerOptions() {}
 
 		public TopicOverseerOptions(IConfiguration conf)
 		{
-			CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS =
-				conf["CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS"];
+			CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS =
+				conf["CAPABILITY_SERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS"];
 		}
 	}
 }

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseerOptions.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Metrics/TopicOverseerOptions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics
+{
+	public class TopicOverseerOptions
+	{
+		public string CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS { get; set; }
+		
+		public TopicOverseerOptions() {}
+
+		public TopicOverseerOptions(IConfiguration conf)
+		{
+			CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS =
+				conf["CAPABILITYSERVICE_FEATURES_TOPIC_METRICS_EVERY_X_SECONDS"];
+		}
+	}
+}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Persistence/EntityFramework/DAOs/Topic.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Persistence/EntityFramework/DAOs/Topic.cs
@@ -10,6 +10,8 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Persistenc
 		public string Name { get; set; }
 		public string Description { get; set; }
 		public Guid CapabilityId { get; set; }
+		public DateTime Created { get; set; }
+		public DateTime LastModified { get; set; }
 
 		public int Partitions { get; set; }
 		
@@ -21,7 +23,9 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Persistenc
 				Name = topic.Name.Name,
 				Description = topic.Description,
 				CapabilityId = topic.CapabilityId,
-				Partitions = topic.Partitions
+				Partitions = topic.Partitions,
+				Created = topic.Created,
+				LastModified = topic.LastModified
 			};
 		}
 	}

--- a/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Persistence/EntityFrameworkTopicRepository.cs
+++ b/src/CapabilityService.WebApi/Features/Kafka/Infrastructure/Persistence/EntityFrameworkTopicRepository.cs
@@ -62,7 +62,9 @@ namespace DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Persistenc
 					t.CapabilityId.ToString(),
 					t.Name,
 					t.Description,
-					t.Partitions
+					t.Partitions,
+					t.Created,
+					t.LastModified
 				)
 			);
 

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -23,6 +23,7 @@ using DFDS.CapabilityService.WebApi.Application.Authentication;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Application;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Events;
 using DFDS.CapabilityService.WebApi.Features.Kafka.Domain.Services;
+using DFDS.CapabilityService.WebApi.Features.Kafka.Infrastructure.Metrics;
 using DFDS.CapabilityService.WebApi.Infrastructure.Api;
 using KafkaJanitor.RestClient;
 using Microsoft.AspNetCore.Authentication.AzureAD.UI;
@@ -57,7 +58,8 @@ namespace DFDS.CapabilityService.WebApi
             services.AddMetrics();
 
             services.AddKafkaJanitorRestClient(Configuration);
-
+            
+            services.AddTopicMetrics();
 
             services
                 .AddPrometheusHealthCheck()

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -58,9 +58,7 @@ namespace DFDS.CapabilityService.WebApi
             services.AddMetrics();
 
             services.AddKafkaJanitorRestClient(Configuration);
-
-            services.AddOptions<TopicOverseerOptions>();
-            services.AddTopicMetrics();
+            services.AddTopicMetrics(Configuration);
 
             services
                 .AddPrometheusHealthCheck()

--- a/src/CapabilityService.WebApi/Startup.cs
+++ b/src/CapabilityService.WebApi/Startup.cs
@@ -58,7 +58,8 @@ namespace DFDS.CapabilityService.WebApi
             services.AddMetrics();
 
             services.AddKafkaJanitorRestClient(Configuration);
-            
+
+            services.AddOptions<TopicOverseerOptions>();
             services.AddTopicMetrics();
 
             services


### PR DESCRIPTION
Added created and last modified columns to Topic table.

Extended metrics for Topics. If there are more topics in Confluent Cloud than in CapSvc, then it'll go in minus. If there are less topics in Confluent Cloud than in CapSvc, then it'll go in surplus. If everything is fine, then it'll be zero.

Story details: https://app.clubhouse.io/devex/story/2063