### PR TITLE
Replace CompactJsonFormatter 

### DIFF
--- a/src/CapabilityService.WebApi/Program.cs
+++ b/src/CapabilityService.WebApi/Program.cs
@@ -39,7 +39,7 @@ namespace DFDS.CapabilityService.WebApi
             }
             else
             {
-                logcfg.WriteTo.Console(new CompactJsonFormatter());
+                logcfg.WriteTo.Console(new JsonFormatter());
             }
 
             Log.Logger = logcfg.CreateLogger();


### PR DESCRIPTION
with JsonFormatter in order to test autoinstrumentation for Datadog TraceID injection.

https://docs.datadoghq.com/tracing/connect_logs_and_traces/dotnet/?tab=serilog