### PR TITLE
Avoid CapabilityFactory producing RootID containing double dashes

### DIFF
--- a/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
+++ b/src/CapabilityService.Tests/Domain/Models/TestCapability.cs
@@ -23,7 +23,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
                 comparer: new PropertiesComparer<IDomainEvent>()
             );
         }
-        
+
         [Fact]
         public async Task rootid_is_generated_when_creating_a_capability()
         {
@@ -31,7 +31,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             var capability = await _capabilityFactory.Create(name,"bar");
 
            Assert.StartsWith($"{name.ToLower()}-", capability.RootId);
-   
+
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
 
            Assert.NotEqual(capabilityOne.RootId, capabilityTwo.RootId);
         }
-        
+
         [Fact]
         public async Task rootid_is_generated_from_id()
         {
@@ -51,8 +51,17 @@ namespace DFDS.CapabilityService.Tests.Domain.Models
             var capability = await _capabilityFactory.Create(name,"bar");
 
             var idPartFromRootId = capability.RootId.Split('-').First();
-            
+
             Assert.StartsWith(idPartFromRootId, capability.RootId);
+        }
+
+        [Fact]
+        public async Task rootid_is_does_not_contain_double_dash()
+        {
+            var name = "Iamanice-acapab-ility-service";
+            var capability = await _capabilityFactory.Create(name, "bar");
+
+            Assert.DoesNotContain("--", capability.RootId);
         }
 
         [Theory]

--- a/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
+++ b/src/CapabilityService.WebApi/Domain/Factories/CapabilityFactory.cs
@@ -38,9 +38,18 @@ namespace DFDS.CapabilityService.WebApi.Domain.Factories
             var microHash = new HashidsNet.Hashids(ROOTID_SALT, 5, "abcdefghijklmnopqrstuvwxyz")
                 .EncodeHex(id.ToString("N")).Substring(0, 5);
 
-            var rootId = (name.Length > maxPreservedNameLength)
-                ? $"{name.Substring(0, maxPreservedNameLength)}-{microHash}"
-                : $"{name}-{microHash}";
+            var rootId = $"{name}-{microHash}";
+
+            if (name.Length > maxPreservedNameLength)
+            {
+                rootId = $"{name.Substring(0, maxPreservedNameLength)}-{microHash}";
+
+                if (rootId.Contains("--"))
+                {
+                    rootId = rootId.Replace("--", "-");
+                }
+            }
+
             return rootId.ToLowerInvariant();
         }
     }


### PR DESCRIPTION
This bug makes the root id look stupid and also breaks AWS account creation because aliases cannot contain double dashes.